### PR TITLE
Add script to package Stream Deck plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ x86/
 [Aa][Rr][Mm]64/
 bld/
 [Bb]in/
+!starcitizen/bin/.gitkeep
 [Oo]bj/
 [Ll]og/
 

--- a/starcitizen/PackageStreamDeckPlugin.ps1
+++ b/starcitizen/PackageStreamDeckPlugin.ps1
@@ -1,0 +1,29 @@
+# Builds a distributable .streamDeckPlugin archive from the compiled plugin output.
+# Run this after building the project (Debug/Release) to generate the installer file.
+
+[CmdletBinding()]
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release"
+)
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$binRoot = Join-Path $scriptRoot "bin"
+$configurationOutput = Join-Path $binRoot $Configuration
+$pluginFolderName = "com.mhwlng.starcitizen.sdPlugin"
+$sourcePath = Join-Path $configurationOutput $pluginFolderName
+$zipPath = Join-Path $configurationOutput "com.mhwlng.starcitizen.zip"
+$outputPath = Join-Path $configurationOutput "com.mhwlng.starcitizen.streamDeckPlugin"
+
+New-Item -ItemType Directory -Force -Path $configurationOutput | Out-Null
+
+if (-not (Test-Path $sourcePath)) {
+    throw "Not found: $sourcePath. Build the project first to generate the plugin folder."
+}
+
+Remove-Item $zipPath, $outputPath -Force -ErrorAction SilentlyContinue
+
+Compress-Archive -Path $sourcePath -DestinationPath $zipPath -Force
+Move-Item $zipPath $outputPath -Force
+
+Write-Host "Created: $outputPath"


### PR DESCRIPTION
## Summary
- add a script that packages the built Stream Deck plugin into a .streamDeckPlugin file
- keep an empty bin directory in source control to host release outputs

## Testing
- not run (script-only change)


------
)