### PR TITLE
Add joystick binding resolver and virtual input emulation

### DIFF
--- a/starcitizen/Buttons/ActionDelay.cs
+++ b/starcitizen/Buttons/ActionDelay.cs
@@ -242,14 +242,7 @@ namespace starcitizen.Buttons
 
             StreamDeckCommon.ForceStop = false;
 
-            if (!bindingService.TryGetBinding(settings.Function, out var action) || string.IsNullOrWhiteSpace(action.Keyboard))
-            {
-                ResetToIdle();
-                return;
-            }
-
-            var keyInfo = CommandTools.ConvertKeyString(action.Keyboard);
-            if (string.IsNullOrWhiteSpace(keyInfo))
+            if (!InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
             {
                 ResetToIdle();
                 return;
@@ -257,7 +250,11 @@ namespace starcitizen.Buttons
 
             try
             {
-                StreamDeckCommon.SendKeypress(keyInfo, 40);
+                if (!InputDispatchService.TrySendPress(binding, 40, settings.Function))
+                {
+                    ResetToIdle();
+                    return;
+                }
             }
             catch (Exception ex)
             {

--- a/starcitizen/Buttons/ActionKey.cs
+++ b/starcitizen/Buttons/ActionKey.cs
@@ -86,11 +86,9 @@ namespace starcitizen.Buttons
 
             StreamDeckCommon.ForceStop = false;
 
-            if (bindingService.TryGetBinding(settings.Function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
             {
-                Logger.Instance.LogMessage(TracingLevel.INFO, CommandTools.ConvertKeyString(action.Keyboard));
-
-                StreamDeckCommon.SendKeypressDown(CommandTools.ConvertKeyString(action.Keyboard));
+                InputDispatchService.TrySendDown(binding, settings.Function);
             }
 
             if (_clickSound != null)
@@ -119,11 +117,9 @@ namespace starcitizen.Buttons
 
             StreamDeckCommon.ForceStop = false;
 
-            if (bindingService.TryGetBinding(settings.Function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
             {
-                Logger.Instance.LogMessage(TracingLevel.INFO, CommandTools.ConvertKeyString(action.Keyboard));
-
-                StreamDeckCommon.SendKeypressUp(CommandTools.ConvertKeyString(action.Keyboard));
+                InputDispatchService.TrySendUp(binding, settings.Function);
             }
 
         }

--- a/starcitizen/Buttons/Dial.cs
+++ b/starcitizen/Buttons/Dial.cs
@@ -123,10 +123,9 @@ namespace starcitizen.Buttons
 
             var function = payload.IsLongPress ? settings.FunctionTouchLongPress : settings.FunctionTouchPress;
 
-            if (bindingService.TryGetBinding(function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, function, out var binding))
             {
-                var key = CommandTools.ConvertKeyString(action.Keyboard);
-                StreamDeckCommon.SendKeypress(key, GetPressDurationMs());
+                InputDispatchService.TrySendPress(binding, GetPressDurationMs(), function);
             }
         }
 
@@ -140,10 +139,9 @@ namespace starcitizen.Buttons
 
             StreamDeckCommon.ForceStop = false;
 
-            if (bindingService.TryGetBinding(settings.FunctionPress, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.FunctionPress, out var binding))
             {
-                var key = CommandTools.ConvertKeyString(action.Keyboard);
-                StreamDeckCommon.SendKeypressDown(key);
+                InputDispatchService.TrySendDown(binding, settings.FunctionPress);
             }
         }
 
@@ -157,10 +155,9 @@ namespace starcitizen.Buttons
 
             StreamDeckCommon.ForceStop = false;
 
-            if (bindingService.TryGetBinding(settings.FunctionPress, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.FunctionPress, out var binding))
             {
-                var key = CommandTools.ConvertKeyString(action.Keyboard);
-                StreamDeckCommon.SendKeypressUp(key);
+                InputDispatchService.TrySendUp(binding, settings.FunctionPress);
             }
         }
 
@@ -279,10 +276,9 @@ namespace starcitizen.Buttons
         {
             var function = clockwise ? settings.FunctionCw : settings.FunctionCcw;
 
-            if (bindingService.TryGetBinding(function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, function, out var binding))
             {
-                var key = CommandTools.ConvertKeyString(action.Keyboard);
-                StreamDeckCommon.SendKeypress(key, GetPressDurationMs());
+                InputDispatchService.TrySendPress(binding, GetPressDurationMs(), function);
             }
         }
 

--- a/starcitizen/Buttons/DualAction.cs
+++ b/starcitizen/Buttons/DualAction.cs
@@ -90,27 +90,27 @@ namespace starcitizen.Buttons
 
         private void SendDownAction()
         {
-            if (!bindingService.TryGetBinding(settings.DownFunction, out var action))
+            if (!InputDispatchService.TryResolveBinding(bindingService, settings.DownFunction, out var binding))
             {
                 return;
             }
 
-            StreamDeckCommon.SendKeypressDown(CommandTools.ConvertKeyString(action.Keyboard));
+            InputDispatchService.TrySendDown(binding, settings.DownFunction);
         }
 
         private void SendUpAction()
         {
-            if (bindingService.TryGetBinding(settings.DownFunction, out var downAction))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.DownFunction, out var downBinding))
             {
-                StreamDeckCommon.SendKeypressUp(CommandTools.ConvertKeyString(downAction.Keyboard));
+                InputDispatchService.TrySendUp(downBinding, settings.DownFunction);
             }
 
-            if (!bindingService.TryGetBinding(settings.UpFunction, out var upAction) || settings.UpFunction == settings.DownFunction)
+            if (!InputDispatchService.TryResolveBinding(bindingService, settings.UpFunction, out var upBinding) || settings.UpFunction == settings.DownFunction)
             {
                 return;
             }
 
-            StreamDeckCommon.SendKeypress(CommandTools.ConvertKeyString(upAction.Keyboard), 40);
+            InputDispatchService.TrySendPress(upBinding, 40, settings.UpFunction);
         }
 
         public override void ReceivedSettings(ReceivedSettingsPayload payload)

--- a/starcitizen/Buttons/FunctionListBuilder.cs
+++ b/starcitizen/Buttons/FunctionListBuilder.cs
@@ -10,6 +10,7 @@ namespace starcitizen.Buttons
     internal static class FunctionListBuilder
     {
         private static readonly object CacheLock = new object();
+        private static readonly InputBindingResolver BindingResolver = new InputBindingResolver();
         private static int cachedVersion = -1;
         private static JArray cachedFunctions;
 
@@ -66,34 +67,13 @@ namespace starcitizen.Buttons
 
                     foreach (var action in group.OrderBy(x => x.MapUICategory).ThenBy(x => x.UILabel))
                     {
-                        string primaryBinding = "";
-                        string bindingType = "";
-
-                        if (!string.IsNullOrWhiteSpace(action.Keyboard))
+                        var resolved = BindingResolver.Resolve(action, culture);
+                        if (resolved.BindingType == InputBindingType.None)
                         {
-                            var keyString = CommandTools.ConvertKeyStringToLocale(action.Keyboard, culture.Name);
-                            primaryBinding = keyString
-                                .Replace("Dik", "")
-                                .Replace("}{", "+")
-                                .Replace("}", "")
-                                .Replace("{", "");
-                            bindingType = "keyboard";
+                            continue;
                         }
-                        else if (!string.IsNullOrWhiteSpace(action.Mouse))
-                        {
-                            primaryBinding = action.Mouse;
-                            bindingType = "mouse";
-                        }
-                        else if (!string.IsNullOrWhiteSpace(action.Joystick))
-                        {
-                            primaryBinding = action.Joystick;
-                            bindingType = "joystick";
-                        }
-                        else if (!string.IsNullOrWhiteSpace(action.Gamepad))
-                        {
-                            primaryBinding = action.Gamepad;
-                            bindingType = "gamepad";
-                        }
+                        string primaryBinding = resolved.BindingDisplay ?? "";
+                        string bindingType = resolved.BindingType.ToString().ToLowerInvariant();
 
                         string bindingDisplay = string.IsNullOrWhiteSpace(primaryBinding) ? "" : $" [{primaryBinding}]";
                         string overruleIndicator = action.KeyboardOverRule || action.MouseOverRule ? " *" : "";

--- a/starcitizen/Buttons/InputBindingResolver.cs
+++ b/starcitizen/Buttons/InputBindingResolver.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using BarRaider.SdTools;
+using SCJMapper_V2.SC;
+using starcitizen.Core;
+
+namespace starcitizen.Buttons
+{
+    internal enum InputBindingType
+    {
+        None,
+        Keyboard,
+        Joystick,
+        Mouse,
+        Gamepad
+    }
+
+    internal enum JoystickBindingKind
+    {
+        Unknown,
+        Button,
+        Hat,
+        Axis
+    }
+
+    internal sealed class JoystickBinding
+    {
+        public string RawValue { get; set; }
+        public string DeviceInstanceName { get; set; }
+        public uint? DeviceId { get; set; }
+        public JoystickBindingKind Kind { get; set; }
+        public int? ButtonNumber { get; set; }
+
+        public string Describe()
+        {
+            if (Kind == JoystickBindingKind.Button && ButtonNumber.HasValue)
+            {
+                return $"{DeviceLabel()}Button {ButtonNumber.Value}";
+            }
+
+            return $"{DeviceLabel()}{RawValue}";
+        }
+
+        private string DeviceLabel()
+        {
+            if (!string.IsNullOrWhiteSpace(DeviceInstanceName))
+            {
+                return $"[{DeviceInstanceName}] ";
+            }
+
+            if (DeviceId.HasValue)
+            {
+                return $"[js{DeviceId.Value}] ";
+            }
+
+            return string.Empty;
+        }
+
+        public static bool TryParse(string raw, string deviceOverride, out JoystickBinding binding)
+        {
+            binding = new JoystickBinding
+            {
+                RawValue = raw?.Trim(),
+                DeviceInstanceName = deviceOverride
+            };
+
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return false;
+            }
+
+            var cleaned = raw.Trim();
+            var match = Regex.Match(cleaned, @"^(js(?<id>\d+)[_\-])?(?<control>.+)$", RegexOptions.IgnoreCase);
+
+            if (match.Success)
+            {
+                var idGroup = match.Groups["id"].Value;
+                if (!string.IsNullOrWhiteSpace(idGroup) && uint.TryParse(idGroup, out var deviceId))
+                {
+                    binding.DeviceId = deviceId;
+                }
+
+                cleaned = match.Groups["control"].Value;
+            }
+
+            var control = cleaned.ToLowerInvariant();
+
+            var buttonMatch = Regex.Match(control, @"button[_\-]?(?<num>\d+)", RegexOptions.IgnoreCase);
+            if (buttonMatch.Success && int.TryParse(buttonMatch.Groups["num"].Value, out var buttonNumber))
+            {
+                binding.Kind = JoystickBindingKind.Button;
+                binding.ButtonNumber = buttonNumber;
+                return true;
+            }
+
+            if (Regex.IsMatch(control, @"hat", RegexOptions.IgnoreCase))
+            {
+                binding.Kind = JoystickBindingKind.Hat;
+                return true;
+            }
+
+            if (Regex.IsMatch(control, @"axis", RegexOptions.IgnoreCase))
+            {
+                binding.Kind = JoystickBindingKind.Axis;
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    internal sealed class ResolvedBinding
+    {
+        public static ResolvedBinding None { get; } = new ResolvedBinding { BindingType = InputBindingType.None };
+
+        public InputBindingType BindingType { get; set; }
+        public string BindingDisplay { get; set; }
+        public string KeyboardBinding { get; set; }
+        public string KeyboardMacro { get; set; }
+        public string RawJoystick { get; set; }
+        public JoystickBinding JoystickBinding { get; set; }
+    }
+
+    /// <summary>
+    /// Chooses the best usable binding for an action. Preference order:
+    /// keyboard, joystick, mouse, then gamepad.
+    /// </summary>
+    internal sealed class InputBindingResolver
+    {
+        public ResolvedBinding Resolve(DProfileReader.Action action, CultureInfo culture = null)
+        {
+            if (action == null)
+            {
+                return ResolvedBinding.None;
+            }
+
+            var keyboardBinding = BuildKeyboardBinding(action, culture);
+            if (keyboardBinding != null)
+            {
+                return keyboardBinding;
+            }
+
+            var joystickBinding = BuildJoystickBinding(action);
+            if (joystickBinding != null)
+            {
+                return joystickBinding;
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Mouse))
+            {
+                return new ResolvedBinding
+                {
+                    BindingType = InputBindingType.Mouse,
+                    BindingDisplay = action.Mouse
+                };
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Gamepad))
+            {
+                return new ResolvedBinding
+                {
+                    BindingType = InputBindingType.Gamepad,
+                    BindingDisplay = action.Gamepad
+                };
+            }
+
+            return ResolvedBinding.None;
+        }
+
+        private ResolvedBinding BuildKeyboardBinding(DProfileReader.Action action, CultureInfo culture)
+        {
+            if (string.IsNullOrWhiteSpace(action.Keyboard))
+            {
+                return null;
+            }
+
+            var macro = CommandTools.ConvertKeyString(action.Keyboard);
+            if (string.IsNullOrWhiteSpace(macro))
+            {
+                PluginLog.Warn($"Keyboard binding '{action.Keyboard}' could not be converted for action '{action.Name}'.");
+                return null;
+            }
+
+            var display = macro;
+            if (culture != null)
+            {
+                display = CommandTools.ConvertKeyStringToLocale(action.Keyboard, culture.Name)
+                    .Replace("Dik", "")
+                    .Replace("}{", "+")
+                    .Replace("}", "")
+                    .Replace("{", "");
+            }
+
+            return new ResolvedBinding
+            {
+                BindingType = InputBindingType.Keyboard,
+                KeyboardBinding = action.Keyboard,
+                KeyboardMacro = macro,
+                BindingDisplay = display
+            };
+        }
+
+        private ResolvedBinding BuildJoystickBinding(DProfileReader.Action action)
+        {
+            if (string.IsNullOrWhiteSpace(action.Joystick))
+            {
+                return null;
+            }
+
+            if (!JoystickBinding.TryParse(action.Joystick, action.JoystickOverRule, out var parsed))
+            {
+                PluginLog.Warn($"Unsupported joystick binding format '{action.Joystick}' for action '{action.Name}'.");
+                return null;
+            }
+
+            return new ResolvedBinding
+            {
+                BindingType = InputBindingType.Joystick,
+                RawJoystick = action.Joystick,
+                JoystickBinding = parsed,
+                BindingDisplay = parsed.Describe()
+            };
+        }
+    }
+}

--- a/starcitizen/Buttons/InputDispatchService.cs
+++ b/starcitizen/Buttons/InputDispatchService.cs
@@ -1,0 +1,116 @@
+using BarRaider.SdTools;
+using starcitizen.Core;
+
+namespace starcitizen.Buttons
+{
+    internal static class InputDispatchService
+    {
+        private static readonly InputBindingResolver Resolver = new InputBindingResolver();
+        private static readonly JoystickInputSender JoystickSender = JoystickInputSender.Instance;
+
+        public static bool TryResolveBinding(KeyBindingService bindingService, string functionName, out ResolvedBinding binding)
+        {
+            binding = ResolvedBinding.None;
+
+            if (bindingService == null || bindingService.Reader == null || string.IsNullOrWhiteSpace(functionName))
+            {
+                return false;
+            }
+
+            if (!bindingService.TryGetBinding(functionName, out var action))
+            {
+                return false;
+            }
+
+            binding = Resolver.Resolve(action);
+            if (binding.BindingType == InputBindingType.None)
+            {
+                return false;
+            }
+
+            if (binding.BindingType == InputBindingType.Joystick &&
+                (binding.JoystickBinding == null || binding.JoystickBinding.Kind != JoystickBindingKind.Button))
+            {
+                PluginLog.Warn($"Joystick binding '{binding.RawJoystick ?? binding.BindingDisplay}' for '{functionName}' is not a supported button mapping.");
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool TrySendPress(ResolvedBinding binding, int durationMs, string contextName)
+        {
+            switch (binding.BindingType)
+            {
+                case InputBindingType.Keyboard:
+                    return SendKeyboardPress(binding, durationMs);
+                case InputBindingType.Joystick:
+                    return JoystickSender.TrySendButtonPulse(binding.JoystickBinding, durationMs, contextName);
+                default:
+                    PluginLog.Warn($"No supported binding found for '{contextName}'.");
+                    return false;
+            }
+        }
+
+        public static bool TrySendDown(ResolvedBinding binding, string contextName)
+        {
+            switch (binding.BindingType)
+            {
+                case InputBindingType.Keyboard:
+                    return SendKeyboardDown(binding);
+                case InputBindingType.Joystick:
+                    return JoystickSender.TrySendButtonDown(binding.JoystickBinding);
+                default:
+                    PluginLog.Warn($"No supported binding found for '{contextName}'.");
+                    return false;
+            }
+        }
+
+        public static bool TrySendUp(ResolvedBinding binding, string contextName)
+        {
+            switch (binding.BindingType)
+            {
+                case InputBindingType.Keyboard:
+                    return SendKeyboardUp(binding);
+                case InputBindingType.Joystick:
+                    return JoystickSender.TrySendButtonUp(binding.JoystickBinding);
+                default:
+                    PluginLog.Warn($"No supported binding found for '{contextName}'.");
+                    return false;
+            }
+        }
+
+        private static bool SendKeyboardPress(ResolvedBinding binding, int durationMs)
+        {
+            if (string.IsNullOrWhiteSpace(binding.KeyboardMacro))
+            {
+                return false;
+            }
+
+            StreamDeckCommon.SendKeypress(binding.KeyboardMacro, durationMs);
+            return true;
+        }
+
+        private static bool SendKeyboardDown(ResolvedBinding binding)
+        {
+            if (string.IsNullOrWhiteSpace(binding.KeyboardMacro))
+            {
+                return false;
+            }
+
+            StreamDeckCommon.SendKeypressDown(binding.KeyboardMacro);
+            return true;
+        }
+
+        private static bool SendKeyboardUp(ResolvedBinding binding)
+        {
+            if (string.IsNullOrWhiteSpace(binding.KeyboardMacro))
+            {
+                return false;
+            }
+
+            StreamDeckCommon.SendKeypressUp(binding.KeyboardMacro);
+            return true;
+        }
+    }
+}

--- a/starcitizen/Buttons/JoystickInputSender.cs
+++ b/starcitizen/Buttons/JoystickInputSender.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using BarRaider.SdTools;
+using starcitizen.Core;
+
+namespace starcitizen.Buttons
+{
+    internal sealed class JoystickInputSender : IDisposable
+    {
+        private const uint DefaultDeviceId = 1;
+
+        private static readonly Lazy<JoystickInputSender> LazyInstance =
+            new Lazy<JoystickInputSender>(() => new JoystickInputSender());
+
+        private readonly object sync = new object();
+        private bool availabilityChecked;
+        private bool available;
+        private uint activeDeviceId = DefaultDeviceId;
+        private bool disposed;
+
+        private JoystickInputSender()
+        {
+        }
+
+        public static JoystickInputSender Instance => LazyInstance.Value;
+
+        public bool IsAvailable
+        {
+            get
+            {
+                EnsureAvailability();
+                return available;
+            }
+        }
+
+        public bool TrySendButtonPulse(JoystickBinding binding, int durationMs, string functionName)
+        {
+            if (!EnsureDevice(binding, functionName))
+            {
+                return false;
+            }
+
+            if (!TrySendButtonDown(binding))
+            {
+                return false;
+            }
+
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(Math.Max(1, durationMs));
+                TrySendButtonUp(binding);
+            });
+
+            return true;
+        }
+
+        public bool TrySendButtonDown(JoystickBinding binding)
+        {
+            if (!EnsureDevice(binding, binding?.RawValue))
+            {
+                return false;
+            }
+
+            return SetBtn(true, activeDeviceId, (uint)(binding.ButtonNumber ?? 1));
+        }
+
+        public bool TrySendButtonUp(JoystickBinding binding)
+        {
+            if (!EnsureDevice(binding, binding?.RawValue))
+            {
+                return false;
+            }
+
+            return SetBtn(false, activeDeviceId, (uint)(binding.ButtonNumber ?? 1));
+        }
+
+        private bool EnsureDevice(JoystickBinding binding, string context)
+        {
+            if (binding == null)
+            {
+                PluginLog.Warn($"Joystick binding was null for '{context}', skipping send.");
+                return false;
+            }
+
+            if (binding.Kind != JoystickBindingKind.Button || !binding.ButtonNumber.HasValue)
+            {
+                PluginLog.Warn($"Joystick binding '{binding.RawValue}' is not a simple button. Emulation supports buttons only.");
+                return false;
+            }
+
+            if (!EnsureAvailability())
+            {
+                return false;
+            }
+
+            var targetDeviceId = binding.DeviceId ?? DefaultDeviceId;
+
+            lock (sync)
+            {
+                if (activeDeviceId != targetDeviceId)
+                {
+                    ReleaseDevice(activeDeviceId);
+                    activeDeviceId = targetDeviceId;
+                }
+
+                var status = GetVJDStatus(activeDeviceId);
+                if (status == VjdStat.VJD_STAT_OWN || status == VjdStat.VJD_STAT_FREE)
+                {
+                    if (AcquireVJD(activeDeviceId))
+                    {
+                        return true;
+                    }
+
+                    PluginLog.Warn($"Failed to acquire virtual joystick {activeDeviceId} for '{context}'. Status: {status}.");
+                    return false;
+                }
+
+                PluginLog.Warn($"Virtual joystick {activeDeviceId} not ready (status {status}); skipping '{context}'.");
+                return false;
+            }
+        }
+
+        private bool EnsureAvailability()
+        {
+            if (availabilityChecked)
+            {
+                return available;
+            }
+
+            availabilityChecked = true;
+
+            try
+            {
+                available = vJoyEnabled();
+                if (!available)
+                {
+                    PluginLog.Warn("vJoy driver not detected. Joystick emulation is disabled.");
+                }
+            }
+            catch (DllNotFoundException)
+            {
+                available = false;
+                PluginLog.Warn("vJoyInterface.dll not found. Install vJoy to enable joystick emulation.");
+            }
+            catch (Exception ex)
+            {
+                available = false;
+                PluginLog.Warn($"Unable to initialize joystick emulation: {ex.Message}");
+            }
+
+            return available;
+        }
+
+        private void ReleaseDevice(uint deviceId)
+        {
+            try
+            {
+                RelinquishVJD(deviceId);
+            }
+            catch
+            {
+                // Ignore release failures
+            }
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            ReleaseDevice(activeDeviceId);
+        }
+
+        private enum VjdStat
+        {
+            VJD_STAT_OWN = 0,
+            VJD_STAT_FREE = 1,
+            VJD_STAT_BUSY = 2,
+            VJD_STAT_MISS = 3,
+            VJD_STAT_UNKN = 4
+        }
+
+        [DllImport("vJoyInterface.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool vJoyEnabled();
+
+        [DllImport("vJoyInterface.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern VjdStat GetVJDStatus(uint rId);
+
+        [DllImport("vJoyInterface.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool AcquireVJD(uint rId);
+
+        [DllImport("vJoyInterface.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern void RelinquishVJD(uint rId);
+
+        [DllImport("vJoyInterface.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern bool SetBtn(bool value, uint rId, uint nBtn);
+    }
+}

--- a/starcitizen/Buttons/Momentary.cs
+++ b/starcitizen/Buttons/Momentary.cs
@@ -66,18 +66,9 @@ namespace starcitizen.Buttons
         {
             if (bindingService.Reader == null) return;
 
-            if (bindingService.TryGetBinding(settings.Function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
             {
-                var keyString = CommandTools.ConvertKeyString(action.Keyboard);
-
-                if (!string.IsNullOrEmpty(keyString))
-                {
-                    StreamDeckCommon.SendKeypressDown(keyString);
-                }
-                else
-                {
-                    Logger.Instance.LogMessage(TracingLevel.WARN, $"Momentary action '{settings.Function}' missing keyboard binding; skipping KeyPressed send.");
-                }
+                InputDispatchService.TrySendDown(binding, settings.Function);
             }
 
             PlayClickSound();
@@ -87,18 +78,9 @@ namespace starcitizen.Buttons
         {
             if (bindingService.Reader == null) return;
 
-            if (bindingService.TryGetBinding(settings.Function, out var action))
+            if (InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
             {
-                var keyString = CommandTools.ConvertKeyString(action.Keyboard);
-
-                if (!string.IsNullOrEmpty(keyString))
-                {
-                    StreamDeckCommon.SendKeypressUp(keyString);
-                }
-                else
-                {
-                    Logger.Instance.LogMessage(TracingLevel.WARN, $"Momentary action '{settings.Function}' missing keyboard binding; skipping KeyReleased send.");
-                }
+                InputDispatchService.TrySendUp(binding, settings.Function);
             }
 
             // 🔑 ALWAYS prefer live payload value

--- a/starcitizen/Buttons/StateMemory.cs
+++ b/starcitizen/Buttons/StateMemory.cs
@@ -190,15 +190,12 @@ namespace starcitizen.Buttons
                 if (bindingService.Reader == null) return;
                 if (string.IsNullOrWhiteSpace(settings.Function)) return;
 
-                var binding = bindingService.Reader.GetBinding(settings.Function);
-                var keyboard = binding != null ? binding.Keyboard : null;
+                if (!InputDispatchService.TryResolveBinding(bindingService, settings.Function, out var binding))
+                {
+                    return;
+                }
 
-                if (string.IsNullOrWhiteSpace(keyboard)) return;
-
-                var converted = CommandTools.ConvertKeyString(keyboard);
-                if (string.IsNullOrWhiteSpace(converted)) return;
-
-                StreamDeckCommon.SendKeypress(converted, settings.KeypressDelayMs);
+                InputDispatchService.TrySendPress(binding, settings.KeypressDelayMs, settings.Function);
             }
             catch (Exception ex)
             {

--- a/starcitizen/Core/PropertyInspectorMessenger.cs
+++ b/starcitizen/Core/PropertyInspectorMessenger.cs
@@ -21,7 +21,8 @@ namespace starcitizen.Core
                 var payload = new JObject
                 {
                     ["functionsLoaded"] = true,
-                    ["functions"] = functionsData
+                    ["functions"] = functionsData,
+                    ["joystickSupport"] = JoystickInputSender.Instance.IsAvailable
                 };
 
                 return connection.SendToPropertyInspectorAsync(payload);

--- a/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
@@ -16,11 +16,13 @@
   <script src="../sdtools.common.js"></script>
   <script src="../jquery-3.3.1.min.js"></script>
   <script src="../jquery.highlight-within-textarea.js"></script>
+  <script src="../binding-notice.js"></script>
 
   <style>
     .note { font-size: 11px; color: #999; line-height: 1.4; }
     .hidden { display: none; }
     .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
+    .binding-note { font-size: 11px; color: #e5c07b; line-height: 1.4; margin-top: 4px; }
   </style>
 </head>
 
@@ -46,6 +48,10 @@
             onchange="setSettings()">
       <option value="">Loading Star Citizen functions...</option>
     </select>
+  </div>
+  <div class="sdpi-item">
+    <div class="sdpi-item-label"></div>
+    <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
   </div>
 
   <div class="sdpi-item">
@@ -165,6 +171,7 @@
         const option = document.createElement('option');
         option.value = opt.value;
         option.textContent = opt.text;
+        option.dataset.bindingType = opt.bindingType || '';
         option.dataset.search = opt.searchText || opt.text.toLowerCase();
 
         optgroup.appendChild(option);
@@ -188,6 +195,8 @@
     }
 
     filterOptions();
+    scWireBindingNotice('function', 'bindingNotice');
+    scUpdateBindingNotice(select, document.getElementById('bindingNotice'));
   }
 
   function filterOptions() {
@@ -239,6 +248,9 @@
       if (jsonObj.event === 'sendToPropertyInspector'
           && jsonObj.payload
           && jsonObj.payload.functionsLoaded) {
+        if (jsonObj.payload.joystickSupport !== undefined) {
+          scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+        }
         populateDropdown(jsonObj.payload.functions);
       }
       if (originalOnMessage) {
@@ -252,6 +264,13 @@
       .addEventListener('input', function () {
         clearTimeout(this.searchTimeout);
         this.searchTimeout = setTimeout(filterOptions, 150);
+      });
+
+    document.getElementById('function')
+      .addEventListener('change', function () {
+        scUpdateBindingNotice(
+          document.getElementById('function'),
+          document.getElementById('bindingNotice'));
       });
 
     updateClearSoundVisibility();

--- a/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results {
@@ -25,6 +26,12 @@
         }
         .hidden {
             display: none !important;
+        }
+        .binding-note {
+            font-size: 11px;
+            color: #e5c07b;
+            margin-top: 4px;
+            line-height: 1.4;
         }
     </style>
 </head>
@@ -56,6 +63,10 @@
                 Loading Star Citizen functions...
             </option>
         </select>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
     </div>
 
     <!-- CLICK SOUND -->
@@ -129,6 +140,7 @@
                 const option = document.createElement('option');
                 option.value = opt.value;
                 option.textContent = opt.text;
+                option.dataset.bindingType = opt.bindingType || '';
                 option.dataset.search = opt.searchText || opt.text.toLowerCase();
 
                 optgroup.appendChild(option);
@@ -148,6 +160,9 @@
         if (savedFunctionValue) {
             select.value = savedFunctionValue;
         }
+
+        scWireBindingNotice('function', 'bindingNotice');
+        scUpdateBindingNotice(select, document.getElementById('bindingNotice'));
     }
 
     function filterOptions() {
@@ -203,6 +218,9 @@
             if (jsonObj.event === 'sendToPropertyInspector'
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
                 populateDropdown(jsonObj.payload.functions);
             }
             if (originalOnMessage) {
@@ -222,6 +240,9 @@
             .addEventListener('change', function () {
                 document.getElementById('functionSearch').value = '';
                 document.getElementById('searchResults').textContent = '';
+                scUpdateBindingNotice(
+                    document.getElementById('function'),
+                    document.getElementById('bindingNotice'));
             });
 
         updateClearSoundVisibility();

--- a/starcitizen/PropertyInspector/StarCitizen/Dial.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Dial.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results {
@@ -25,6 +26,12 @@
         }
         .hidden {
             display: none !important;
+        }
+        .binding-note {
+            font-size: 11px;
+            color: #e5c07b;
+            margin-top: 4px;
+            line-height: 1.4;
         }
     </style>
 </head>
@@ -97,6 +104,11 @@
     </div>
 
     <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
+    </div>
+
+    <div class="sdpi-item">
         <div class="sdpi-item-label">Touch Delay (ms)</div>
         <input type="number"
                class="sdpi-item-value sdProperty"
@@ -161,6 +173,7 @@
                     const option = document.createElement('option');
                     option.value = opt.value;
                     option.textContent = opt.text;
+                    option.dataset.bindingType = opt.bindingType || '';
                     option.dataset.search = (opt.searchText || opt.text || '').toLowerCase();
 
                     optgroup.appendChild(option);
@@ -212,6 +225,29 @@
         searchResults.textContent = term
             ? `Found ${count} group${count !== 1 ? 's' : ''}`
             : '';
+
+        updateBindingNotice();
+    }
+
+    function updateBindingNotice() {
+        const notice = document.getElementById('bindingNotice');
+        if (!notice) return;
+
+        const selects = document.querySelectorAll('.function-select');
+        const hasJoystick = Array.from(selects).some(sel => {
+            const opt = sel.selectedOptions && sel.selectedOptions[0];
+            return opt && (opt.dataset.bindingType || '').toLowerCase() === 'joystick';
+        });
+
+        if (hasJoystick) {
+            notice.classList.remove('hidden');
+            notice.textContent = joystickSupportStatus === false
+                ? 'One or more dial functions use joystick bindings. No virtual joystick was detected, so those actions may be skipped.'
+                : 'One or more dial functions use joystick bindings. The plugin will emulate those joystick buttons when needed.';
+        } else {
+            notice.classList.add('hidden');
+            notice.textContent = '';
+        }
     }
 
     document.addEventListener('websocketCreate', function () {
@@ -221,6 +257,9 @@
             if (jsonObj.event === 'sendToPropertyInspector'
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
                 populateDropdowns(jsonObj.payload.functions);
             }
             if (originalOnMessage) {
@@ -240,6 +279,7 @@
             sel.addEventListener('change', function () {
                 document.getElementById('functionSearch').value = '';
                 document.getElementById('searchResults').textContent = '';
+                updateBindingNotice();
             });
         });
     });

--- a/starcitizen/PropertyInspector/StarCitizen/DualAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/DualAction.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results {
@@ -25,6 +26,12 @@
         }
         .hidden {
             display: none !important;
+        }
+        .binding-note {
+            font-size: 11px;
+            color: #e5c07b;
+            line-height: 1.4;
+            margin-top: 4px;
         }
     </style>
 </head>
@@ -55,6 +62,10 @@
             <option value="">Loading Star Citizen functions…</option>
         </select>
     </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNoticeDown"></div>
+    </div>
 
     <!-- RELEASE FUNCTION -->
     <div class="sdpi-item">
@@ -70,6 +81,10 @@
             Press action is held down until you release the key. When released,
             the press action is released and the optional release action is tapped.
         </details>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNoticeUp"></div>
     </div>
 
     <!-- CLICK SOUND -->
@@ -158,9 +173,11 @@
                 const downOption = document.createElement('option');
                 downOption.value = opt.value;
                 downOption.textContent = opt.text;
+                downOption.dataset.bindingType = opt.bindingType || '';
                 downOption.dataset.search = opt.searchText || opt.text.toLowerCase();
 
                 const upOption = downOption.cloneNode(true);
+                upOption.dataset.bindingType = opt.bindingType || '';
 
                 downGroup.appendChild(downOption);
                 upGroup.appendChild(upOption);
@@ -185,6 +202,11 @@
 
         if (savedDownValue) downSel.value = savedDownValue;
         if (savedUpValue) upSel.value = savedUpValue;
+
+        scWireBindingNotice('downFunction', 'bindingNoticeDown');
+        scWireBindingNotice('upFunction', 'bindingNoticeUp');
+        scUpdateBindingNotice(downSel, document.getElementById('bindingNoticeDown'));
+        scUpdateBindingNotice(upSel, document.getElementById('bindingNoticeUp'));
     }
 
     function filterOptions() {
@@ -254,6 +276,10 @@
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
 
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
+
                 populateDropdown(jsonObj.payload.functions);
             }
 
@@ -276,6 +302,9 @@
                 .addEventListener('change', function () {
                     document.getElementById('functionSearch').value = '';
                     document.getElementById('searchResults').textContent = '';
+                    scUpdateBindingNotice(
+                        document.getElementById(id),
+                        document.getElementById(id === 'downFunction' ? 'bindingNoticeDown' : 'bindingNoticeUp'));
                 });
         });
 

--- a/starcitizen/PropertyInspector/StarCitizen/Momentary.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Momentary.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results {
@@ -25,6 +26,12 @@
         }
         .hidden {
             display: none !important;
+        }
+        .binding-note {
+            font-size: 11px;
+            color: #e5c07b;
+            margin-top: 4px;
+            line-height: 1.4;
         }
     </style>
 </head>
@@ -54,6 +61,10 @@
                 onchange="setSettings()">
             <option value="">Loading Star Citizen functions…</option>
         </select>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
     </div>
 
     <!-- DELAY -->
@@ -116,6 +127,8 @@
             if (sel) sel.value = savedFunctionValue;
         }
 
+        scWireBindingNotice('function', 'bindingNotice');
+        scUpdateBindingNotice(document.getElementById('function'), document.getElementById('bindingNotice'));
         updateClearSoundVisibility();
     };
 
@@ -137,6 +150,7 @@
                 const option = document.createElement('option');
                 option.value = opt.value;
                 option.textContent = opt.text;
+                option.dataset.bindingType = opt.bindingType || '';
                 option.dataset.search = opt.searchText || opt.text.toLowerCase();
 
                 optgroup.appendChild(option);
@@ -156,6 +170,9 @@
         if (savedFunctionValue) {
             select.value = savedFunctionValue;
         }
+
+        scWireBindingNotice('function', 'bindingNotice');
+        scUpdateBindingNotice(select, document.getElementById('bindingNotice'));
     }
 
     function filterOptions() {
@@ -218,6 +235,9 @@
             if (jsonObj.event === 'sendToPropertyInspector'
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
 
                 populateDropdown(jsonObj.payload.functions);
             }
@@ -240,6 +260,9 @@
             .addEventListener('change', function () {
                 document.getElementById('functionSearch').value = '';
                 document.getElementById('searchResults').textContent = '';
+                scUpdateBindingNotice(
+                    document.getElementById('function'),
+                    document.getElementById('bindingNotice'));
             });
 
         updateClearSoundVisibility();

--- a/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results {
@@ -29,6 +30,12 @@
         .note {
             font-size: 11px;
             color: #999;
+            margin-top: 4px;
+            line-height: 1.4;
+        }
+        .binding-note {
+            font-size: 11px;
+            color: #e5c07b;
             margin-top: 4px;
             line-height: 1.4;
         }
@@ -60,6 +67,10 @@
                 onchange="setSettings()">
             <option value="">Loading Star Citizen functions...</option>
         </select>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
     </div>
 
     <!-- REPEAT RATE -->
@@ -129,6 +140,7 @@
                 const option = document.createElement('option');
                 option.value = opt.value;
                 option.textContent = opt.text;
+                option.dataset.bindingType = opt.bindingType || '';
                 option.dataset.search = opt.searchText || opt.text.toLowerCase();
 
                 optgroup.appendChild(option);
@@ -150,6 +162,8 @@
         }
 
         filterOptions();
+        scWireBindingNotice('function', 'bindingNotice');
+        scUpdateBindingNotice(select, document.getElementById('bindingNotice'));
     }
 
     function filterOptions() {
@@ -190,6 +204,9 @@
             if (jsonObj.event === 'sendToPropertyInspector'
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
 
                 populateDropdown(jsonObj.payload.functions);
             }
@@ -211,6 +228,9 @@
             .addEventListener('change', function () {
                 document.getElementById('functionSearch').value = '';
                 document.getElementById('searchResults').textContent = '';
+                scUpdateBindingNotice(
+                    document.getElementById('function'),
+                    document.getElementById('bindingNotice'));
             });
     });
 </script>

--- a/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
+++ b/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
@@ -15,6 +15,7 @@
     <script src="../sdtools.common.js"></script>
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
+    <script src="../binding-notice.js"></script>
 
     <style>
         .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
@@ -23,6 +24,7 @@
         .compact { margin-top: 0; }
         .inline-row { display: flex; align-items: center; gap: 10px; }
         .small-btn { padding: 4px 8px; height: 26px; }
+        .binding-note { font-size: 11px; color: #e5c07b; margin-top: 4px; line-height: 1.4; }
     </style>
 </head>
 
@@ -51,6 +53,10 @@
                 onchange="setSettings()">
             <option value="">Loading Star Citizen functions…</option>
         </select>
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value binding-note hidden" id="bindingNotice"></div>
     </div>
 
     <!-- MEMORY (compact) -->
@@ -200,6 +206,7 @@
                 const option = document.createElement('option');
                 option.value = opt.value;
                 option.textContent = opt.text;
+                option.dataset.bindingType = opt.bindingType || '';
                 option.dataset.search = opt.searchText || opt.text.toLowerCase();
 
                 optgroup.appendChild(option);
@@ -219,6 +226,9 @@
         if (savedFunctionValue) {
             select.value = savedFunctionValue;
         }
+
+        scWireBindingNotice('function', 'bindingNotice');
+        scUpdateBindingNotice(select, document.getElementById('bindingNotice'));
     }
 
     function filterOptions() {
@@ -284,6 +294,10 @@
                 && jsonObj.payload
                 && jsonObj.payload.functionsLoaded) {
 
+                if (jsonObj.payload.joystickSupport !== undefined) {
+                    scSetJoystickSupportFlag(jsonObj.payload.joystickSupport);
+                }
+
                 populateDropdown(jsonObj.payload.functions);
             }
 
@@ -304,6 +318,9 @@
             .addEventListener('change', function () {
                 document.getElementById('functionSearch').value = '';
                 document.getElementById('searchResults').textContent = '';
+                scUpdateBindingNotice(
+                    document.getElementById('function'),
+                    document.getElementById('bindingNotice'));
             });
 
         updateClearButtons();

--- a/starcitizen/PropertyInspector/binding-notice.js
+++ b/starcitizen/PropertyInspector/binding-notice.js
@@ -1,0 +1,33 @@
+let joystickSupportStatus = null;
+
+function scSetJoystickSupportFlag(value) {
+    if (value === true || value === false) {
+        joystickSupportStatus = value;
+    }
+}
+
+function scUpdateBindingNotice(selectElement, noticeElement) {
+    if (!selectElement || !noticeElement) return;
+
+    const selected = selectElement.selectedOptions && selectElement.selectedOptions[0];
+    const bindingType = selected ? (selected.dataset.bindingType || '').toLowerCase() : '';
+
+    if (bindingType === 'joystick') {
+        noticeElement.classList.remove('hidden');
+        noticeElement.textContent = joystickSupportStatus === false
+            ? 'Joystick binding selected. No virtual joystick was detected, so this binding may be skipped. Enable a virtual joystick driver to emulate this binding.'
+            : 'Joystick binding selected. The plugin will emulate this joystick button when no keyboard binding is available.';
+    } else {
+        noticeElement.classList.add('hidden');
+        noticeElement.textContent = '';
+    }
+}
+
+function scWireBindingNotice(selectId, noticeId) {
+    const select = document.getElementById(selectId);
+    const notice = document.getElementById(noticeId);
+    if (!select || !notice) return;
+
+    select.addEventListener('change', () => scUpdateBindingNotice(select, notice));
+    scUpdateBindingNotice(select, notice);
+}

--- a/starcitizen/starcitizen.csproj
+++ b/starcitizen/starcitizen.csproj
@@ -183,10 +183,13 @@
     <Compile Include="Buttons\FunctionListBuilder.cs" />
     <Compile Include="Buttons\DualAction.cs" />
     <Compile Include="Buttons\StateMemory.cs" />
+    <Compile Include="Buttons\InputBindingResolver.cs" />
     <Compile Include="Buttons\StarCitizenDialBase.cs" />
     <Compile Include="Buttons\Dial.cs" />
     <Compile Include="Buttons\Repeataction.cs" />
     <Compile Include="Buttons\Momentary.cs" />
+    <Compile Include="Buttons\InputDispatchService.cs" />
+    <Compile Include="Buttons\JoystickInputSender.cs" />
     <Compile Include="Buttons\StreamDeckCommon.cs" />
     <Compile Include="Buttons\StreamDeckEventArgsExtensions.cs" />
     <Compile Include="Buttons\StarCitizenKeypadBase.cs" />
@@ -320,6 +323,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="PropertyInspector\check.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PropertyInspector\binding-notice.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="PropertyInspector\elg_calendar.svg">


### PR DESCRIPTION
## Summary
- add a binding resolver/dispatch layer that prefers keyboard bindings but can parse joystick entries and route them through a virtual joystick sender
- update all input-sending actions to use the resolver so joystick-only bindings can be emulated while keeping keyboard behavior unchanged
- surface joystick capability status to the property inspector and show in-UI notices when a selected binding relies on joystick emulation

## Testing
- dotnet build starcitizen.sln *(fails: dotnet CLI is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516d4cf374832dbeb5e6b3a9540e2c)