### PR TITLE
Fix joystick binding resolution from actionmaps

### DIFF
--- a/starcitizen/Buttons/InputBindingResolver.cs
+++ b/starcitizen/Buttons/InputBindingResolver.cs
@@ -62,7 +62,6 @@ namespace starcitizen.Buttons
             binding = new JoystickBinding
             {
                 RawValue = raw?.Trim(),
-                DeviceInstanceName = deviceOverride
             };
 
             if (string.IsNullOrWhiteSpace(raw))
@@ -82,6 +81,20 @@ namespace starcitizen.Buttons
                 }
 
                 cleaned = match.Groups["control"].Value;
+            }
+
+            var deviceLabel = deviceOverride?.Trim();
+
+            if (!string.IsNullOrWhiteSpace(deviceLabel))
+            {
+                if (uint.TryParse(deviceLabel, out var overrideId) && !binding.DeviceId.HasValue)
+                {
+                    binding.DeviceId = overrideId;
+                }
+                else
+                {
+                    binding.DeviceInstanceName = deviceLabel;
+                }
             }
 
             var control = cleaned.ToLowerInvariant();


### PR DESCRIPTION
## Summary
- ensure actionmaps overrides are parsed regardless of root node shape so player bindings load
- preserve joystick rebind identifiers and map device instance details for accurate display and sending
- honor numeric overrides when parsing joystick bindings to target the correct virtual device

## Testing
- dotnet build starcitizen.sln *(fails: dotnet is not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695174bf1b6c832dbeeebc45f07a2634)