### PR TITLE
Prioritize joystick rebinds for actions

### DIFF
--- a/starcitizen/Buttons/InputBindingResolver.cs
+++ b/starcitizen/Buttons/InputBindingResolver.cs
@@ -148,7 +148,8 @@ namespace starcitizen.Buttons
                 return ResolvedBinding.None;
             }
 
-            var hasJoystickOverride = !string.IsNullOrWhiteSpace(action.JoystickOverRule);
+            var hasJoystickOverride = action.JoystickOverRuleApplied ||
+                                      !string.IsNullOrWhiteSpace(action.JoystickOverRule);
             var hasKeyboardOverride = action.KeyboardOverRule;
             var hasMouseOverride = action.MouseOverRule;
 

--- a/starcitizen/SC/DProfileReader.cs
+++ b/starcitizen/SC/DProfileReader.cs
@@ -51,6 +51,7 @@ namespace SCJMapper_V2.SC
 
             public bool KeyboardOverRule { get; set; }
             public string JoystickOverRule { get; set; }
+            public bool JoystickOverRuleApplied { get; set; }
             public bool MouseOverRule { get; set; }
 
             public ActivationMode ActivationMode { get; set; }
@@ -286,6 +287,7 @@ namespace SCJMapper_V2.SC
                                 if (!string.IsNullOrEmpty(cleanedInput))
                                 {
                                     map.Actions[actionName].Joystick = cleanedInput;
+                                    map.Actions[actionName].JoystickOverRuleApplied = true;
 
                                     if (!string.IsNullOrWhiteSpace(instance))
                                     {


### PR DESCRIPTION
## Summary
- track when joystick rebinds are applied to actions
- prefer joystick bindings when a rebind is present instead of falling back to default keyboard inputs

## Testing
- dotnet build (fails: command not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951773044d4832db9b86b9ece7e1e61)