### PR TITLE
Optimize keybinding retrieval and prioritize keyboard bindings

### DIFF
--- a/starcitizen/Buttons/FunctionListBuilder.cs
+++ b/starcitizen/Buttons/FunctionListBuilder.cs
@@ -13,6 +13,47 @@ namespace starcitizen.Buttons
         private static int cachedVersion = -1;
         private static JArray cachedFunctions;
 
+        private static bool TryGetPrimaryBinding(DProfileReader.Action action, CultureInfo culture, out string binding, out string bindingType)
+        {
+            binding = string.Empty;
+            bindingType = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(action.Keyboard))
+            {
+                var keyString = CommandTools.ConvertKeyStringToLocale(action.Keyboard, culture.Name);
+                binding = keyString
+                    .Replace("Dik", "")
+                    .Replace("}{", "+")
+                    .Replace("}", "")
+                    .Replace("{", "");
+                bindingType = "keyboard";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Mouse))
+            {
+                binding = action.Mouse;
+                bindingType = "mouse";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Joystick))
+            {
+                binding = action.Joystick;
+                bindingType = "joystick";
+                return true;
+            }
+
+            if (!string.IsNullOrWhiteSpace(action.Gamepad))
+            {
+                binding = action.Gamepad;
+                bindingType = "gamepad";
+                return true;
+            }
+
+            return false;
+        }
+
         public static JArray BuildFunctionsData(bool includeUnboundActions = true)
         {
             var result = new JArray();
@@ -64,36 +105,12 @@ namespace starcitizen.Buttons
                         ["options"] = new JArray()
                     };
 
-                    foreach (var action in group.OrderBy(x => x.MapUICategory).ThenBy(x => x.UILabel))
+                    foreach (var action in group
+                        .OrderByDescending(x => !string.IsNullOrWhiteSpace(x.Keyboard))
+                        .ThenBy(x => x.MapUICategory)
+                        .ThenBy(x => x.UILabel))
                     {
-                        string primaryBinding = "";
-                        string bindingType = "";
-
-                        if (!string.IsNullOrWhiteSpace(action.Keyboard))
-                        {
-                            var keyString = CommandTools.ConvertKeyStringToLocale(action.Keyboard, culture.Name);
-                            primaryBinding = keyString
-                                .Replace("Dik", "")
-                                .Replace("}{", "+")
-                                .Replace("}", "")
-                                .Replace("{", "");
-                            bindingType = "keyboard";
-                        }
-                        else if (!string.IsNullOrWhiteSpace(action.Mouse))
-                        {
-                            primaryBinding = action.Mouse;
-                            bindingType = "mouse";
-                        }
-                        else if (!string.IsNullOrWhiteSpace(action.Joystick))
-                        {
-                            primaryBinding = action.Joystick;
-                            bindingType = "joystick";
-                        }
-                        else if (!string.IsNullOrWhiteSpace(action.Gamepad))
-                        {
-                            primaryBinding = action.Gamepad;
-                            bindingType = "gamepad";
-                        }
+                        TryGetPrimaryBinding(action, culture, out var primaryBinding, out var bindingType);
 
                         string bindingDisplay = string.IsNullOrWhiteSpace(primaryBinding) ? "" : $" [{primaryBinding}]";
                         string overruleIndicator = action.KeyboardOverRule || action.MouseOverRule ? " *" : "";

--- a/starcitizen/Buttons/StateMemory.cs
+++ b/starcitizen/Buttons/StateMemory.cs
@@ -190,7 +190,11 @@ namespace starcitizen.Buttons
                 if (bindingService.Reader == null) return;
                 if (string.IsNullOrWhiteSpace(settings.Function)) return;
 
-                var binding = bindingService.Reader.GetBinding(settings.Function);
+                if (!bindingService.Reader.TryGetBinding(settings.Function, out var binding))
+                {
+                    return;
+                }
+
                 var keyboard = binding != null ? binding.Keyboard : null;
 
                 if (string.IsNullOrWhiteSpace(keyboard)) return;

--- a/starcitizen/Core/KeyBindingService.cs
+++ b/starcitizen/Core/KeyBindingService.cs
@@ -66,8 +66,7 @@ namespace starcitizen.Core
                 return false;
             }
 
-            action = reader.GetBinding(functionName);
-            return action != null;
+            return reader.TryGetBinding(functionName, out action);
         }
 
         public void Dispose()

--- a/starcitizen/SC/DProfileReader.cs
+++ b/starcitizen/SC/DProfileReader.cs
@@ -431,17 +431,19 @@ namespace SCJMapper_V2.SC
 
         public Action GetBinding(string key)
         {
+            return TryGetBinding(key, out var action) ? action : null;
+        }
+
+        public bool TryGetBinding(string key, out Action action)
+        {
+            action = null;
+
             if (string.IsNullOrEmpty(key))
             {
-                return null;
+                return false;
             }
 
-            if (actions.ContainsKey(key))
-            {
-                return actions[key];
-            }
-
-            return null;
+            return actions.TryGetValue(key, out action);
         }
 
         public void CreateCsv(bool enableCsvExport)


### PR DESCRIPTION
## Summary
- add a reader-side TryGetBinding helper and use it in the keybinding service and buttons to avoid redundant lookups
- centralize primary binding selection in the function list builder while ordering keyboard-bound entries ahead of joystick/gamepad bindings
- rely on the new lookup path when sending stored keypresses in StateMemory

## Testing
- dotnet build starcitizen.sln *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951cedcacfc832d8a4a033e14a7474c)