### PR TITLE
Fix duplicate key detection when building function list

### DIFF
--- a/starcitizen/Buttons/FunctionListBuilder.cs
+++ b/starcitizen/Buttons/FunctionListBuilder.cs
@@ -58,6 +58,28 @@ namespace starcitizen.Buttons
 
                 foreach (var group in actions)
                 {
+                    var duplicateKeys = group
+                        .Select(a =>
+                        {
+                            var keyString = CommandTools.ConvertKeyStringToLocale(a.Keyboard, culture.Name);
+                            var primaryBinding = keyString
+                                .Replace("Dik", "")
+                                .Replace("}{", "+")
+                                .Replace("}", "")
+                                .Replace("{", "");
+
+                            return new
+                            {
+                                a.UILabel,
+                                PrimaryBinding = primaryBinding,
+                                BindingType = "keyboard"
+                            };
+                        })
+                        .GroupBy(x => x)
+                        .Where(g => g.Count() > 1)
+                        .Select(g => g.Key)
+                        .ToHashSet();
+
                     var groupObj = new JObject
                     {
                         ["label"] = group.Key,
@@ -82,7 +104,7 @@ namespace starcitizen.Buttons
                         string overruleIndicator = action.KeyboardOverRule || action.MouseOverRule ? " *" : "";
                         string uniqueSuffix = "";
 
-                        if (duplicateKeys.Contains(new { action.UILabel, actionInfo.PrimaryBinding, actionInfo.BindingType }))
+                        if (duplicateKeys.Contains(new { action.UILabel, PrimaryBinding = primaryBinding, BindingType = bindingType }))
                         {
                             var actionName = action.Name?.StartsWith($"{action.MapName}-", StringComparison.OrdinalIgnoreCase) == true
                                 ? action.Name.Substring(action.MapName.Length + 1)


### PR DESCRIPTION
## Summary
- compute duplicate key bindings per group when building function data
- use the computed binding info to decide when to append unique suffixes

## Testing
- Not run (Windows/.NET Framework environment not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955aa802654832db30a868784c7b312)