### PR TITLE
Include MouseTokenHelper in project build

### DIFF
--- a/starcitizen/starcitizen.csproj
+++ b/starcitizen/starcitizen.csproj
@@ -208,6 +208,7 @@
     <Compile Include="CryXMLlib\XmlTree.cs" />
     <Compile Include="FifoExecution.cs" />
     <Compile Include="KeyboardLayouts.cs" />
+    <Compile Include="MouseTokenHelper.cs" />
     <Compile Include="p4kFile\p4kDirectory.cs" />
     <Compile Include="p4kFile\p4kDirectoryEntry.cs" />
     <Compile Include="p4kFile\p4kEndOfCentralDirRecord.cs" />


### PR DESCRIPTION
## Summary
- include MouseTokenHelper.cs in the project so mouse token utilities are compiled
- resolve missing MouseTokenHelper references in command and button helpers

## Testing
- not run (Windows-only .NET Framework build environment not available here)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b515e0ec832d8ef5b2115af52d5a)