### PR TITLE
Fix mouse token detection for older frameworks

### DIFF
--- a/starcitizen/MouseTokenHelper.cs
+++ b/starcitizen/MouseTokenHelper.cs
@@ -64,8 +64,8 @@ namespace starcitizen
                 return false;
             }
 
-            return cleaned.Contains("mouse", StringComparison.OrdinalIgnoreCase) ||
-                   cleaned.Contains("wheel", StringComparison.OrdinalIgnoreCase);
+            return cleaned.IndexOf("mouse", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   cleaned.IndexOf("wheel", StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static string NormalizeForLookup(string token)


### PR DESCRIPTION
## Summary
- replace string.Contains overload usage in mouse token detection with IndexOf for framework compatibility

## Testing
- dotnet build (fails: dotnet command not available in environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b59ae0f0832da85a460879b0a63a)