### PR TITLE
Enable mouse output by default

### DIFF
--- a/starcitizen/SC/SCPath.cs
+++ b/starcitizen/SC/SCPath.cs
@@ -864,9 +864,9 @@ namespace SCJMapper_V2.SC
 
         /// <summary>
         /// Optional feature: allow mouse tokens (mouse1/mwheelup/...) to be sent via InputSimulator.
-        /// Default: false (legacy behavior).
+        /// Default: true (more convenient; can be disabled via appsettings.config).
         /// </summary>
-        public static bool EnableMouseOutput => ReadBoolAppSetting("EnableMouseOutput", false);
+        public static bool EnableMouseOutput => ReadBoolAppSetting("EnableMouseOutput", true);
 
 
 


### PR DESCRIPTION
## Summary
- enable mouse output setting by default so mouse button macros work without extra configuration

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b9cf0ea0832db8a04214e2197706)