### PR TITLE
Improve mouse macro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ then the button image would be out of sync.
 
 The plugin also has a Dial button for use with the 4 dials on the Streamdeck+ model. You’ll find it under the **Dials** section of the Stream Deck+ action list (look for the Star Citizen category with the dial icon).
 
-There are 5 bindings (They must be keyboard bindings, you can't bind the mouse wheel!) :
+There are 5 bindings (keyboard or mouse tokens are supported) :
 
 - Dial Clockwise
 - Dial Counter-Clockwise
@@ -294,8 +294,10 @@ The 'key down' event is sent to the keyboard. After a user-definable delay (defa
 After you install the plugin in the streamdeck software, then there will be new button types in the streamdeck software.
 
 Choose a button in the streamdeck software (drag and drop), then choose a Star Citizen function for that button 
-(that must have a keyboard binding in Star Citizen. **A mouse, gamepad or joystick binding won't work!**) 
+(that must have a keyboard or mouse binding in Star Citizen. **Gamepad or joystick bindings won't work!**) 
 and then choose any picture for that button.
+
+Mouse output (mouse1/mouse2/mwheelup/etc.) is enabled by default and can be toggled in `appsettings.config` using `EnableMouseOutput=true|false`. If mouse clicks or wheel events do not register in-game, make sure Star Citizen is the focused window and run Stream Deck with the same (or higher) privileges as the game.
 
 Add an image to a button in this way:
 

--- a/starcitizen/MouseTokenHelper.cs
+++ b/starcitizen/MouseTokenHelper.cs
@@ -9,10 +9,15 @@ namespace starcitizen
         private static readonly Dictionary<string, string> CanonicalTokens = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["mouse1"] = "mouse1",
+            ["mousebutton1"] = "mouse1",
             ["mouse2"] = "mouse2",
+            ["mousebutton2"] = "mouse2",
             ["mouse3"] = "mouse3",
+            ["mousebutton3"] = "mouse3",
             ["mouse4"] = "mouse4",
+            ["mousebutton4"] = "mouse4",
             ["mouse5"] = "mouse5",
+            ["mousebutton5"] = "mouse5",
             ["mwheelup"] = "mwheelup",
             ["mousewheelup"] = "mwheelup",
             ["wheelup"] = "mwheelup",

--- a/starcitizen/SC/SCPath.cs
+++ b/starcitizen/SC/SCPath.cs
@@ -864,9 +864,9 @@ namespace SCJMapper_V2.SC
 
         /// <summary>
         /// Optional feature: allow mouse tokens (mouse1/mwheelup/...) to be sent via InputSimulator.
-        /// Default: false (legacy behavior).
+        /// Default: true (more convenient; can be disabled via appsettings.config).
         /// </summary>
-        public static bool EnableMouseOutput => ReadBoolAppSetting("EnableMouseOutput", false);
+        public static bool EnableMouseOutput => ReadBoolAppSetting("EnableMouseOutput", true);
 
 
 

--- a/starcitizen/appsettings.config
+++ b/starcitizen/appsettings.config
@@ -40,4 +40,7 @@
 
   <!-- Enable CSV export for key bindings (default: false) -->
   <add key="EnableCsvExport" value="false" />
+
+  <!-- Enable mouse output for Stream Deck actions (default: true) -->
+  <add key="EnableMouseOutput" value="true" />
 </appSettings>


### PR DESCRIPTION
## Summary
- map Star Citizen mouse_button* aliases to mouse macros so InputSimulator can click
- add default EnableMouseOutput entry and document mouse output usage and privilege requirements

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b9cf0ea0832db8a04214e2197706)