### PR TITLE
Add hold macro action for press-and-hold behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ Press-and-hold repeat behavior.
 
 ---
 
+### Hold Macro
+
+Press-and-hold behavior without rapid-fire repeats.
+
+**Behavior:**
+
+1. Press sends the selected function’s **key/mouse down** immediately.
+2. Choose between **Hold until release** (default) or a fixed **Hold duration (ms)** that auto-releases after the timer.
+3. Supports both keyboard and mouse tokens using the existing macro handling.
+
+**Tips:**
+
+- For reliable input injection, keep Star Citizen focused and run the Stream Deck app with admin rights when required by your OS settings.
+- If you enable the duration option, a safety cap limits holds to 60 seconds to avoid accidental “infinite” holds.
+
+**Use cases:**
+
+1. Charge-up/activate workflows where you only want a single held input
+2. Mouse-button style holds (e.g., ADS) without triggering repeats
+3. Any “hold to engage, release to stop” macro
+
+---
+
 ### Cosmetic
 <img width="100" height="100" alt="Cosmetic" src="https://github.com/user-attachments/assets/6891af8c-352b-4c2c-81d4-335df945e9b8" />
 

--- a/starcitizen/Buttons/HoldMacroAction.cs
+++ b/starcitizen/Buttons/HoldMacroAction.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BarRaider.SdTools;
+using BarRaider.SdTools.Events;
+using BarRaider.SdTools.Wrappers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using starcitizen.Core;
+
+namespace starcitizen.Buttons
+{
+    [PluginActionId("com.ltmajor42.starcitizen.holdmacro")]
+    public class HoldMacroAction : StarCitizenKeypadBase
+    {
+        protected class PluginSettings
+        {
+            public static PluginSettings CreateDefaultSettings()
+            {
+                return new PluginSettings
+                {
+                    Function = string.Empty,
+                    HoldDurationMs = 0,
+                    HoldUntilRelease = true
+                };
+            }
+
+            [JsonProperty(PropertyName = "function")]
+            public string Function { get; set; }
+
+            [JsonProperty(PropertyName = "holdDurationMs")]
+            public int HoldDurationMs { get; set; }
+
+            [JsonProperty(PropertyName = "holdUntilRelease")]
+            public bool HoldUntilRelease { get; set; }
+        }
+
+        private const int MaxHoldDurationMs = 60000;
+
+        private PluginSettings settings;
+        private readonly KeyBindingService bindingService = KeyBindingService.Instance;
+        private CancellationTokenSource autoReleaseToken;
+        private string activeKeyInfo;
+        private bool isKeyDown;
+
+        public HoldMacroAction(SDConnection connection, InitialPayload payload) : base(connection, payload)
+        {
+            settings = PluginSettings.CreateDefaultSettings();
+
+            if (payload.Settings != null && payload.Settings.Count > 0)
+            {
+                Tools.AutoPopulateSettings(settings, payload.Settings);
+                ClampHoldDuration();
+            }
+            else
+            {
+                _ = Connection.SetSettingsAsync(JObject.FromObject(settings));
+            }
+
+            Connection.OnPropertyInspectorDidAppear += Connection_OnPropertyInspectorDidAppear;
+            Connection.OnSendToPlugin += Connection_OnSendToPlugin;
+            bindingService.KeyBindingsLoaded += OnKeyBindingsLoaded;
+
+            UpdatePropertyInspector();
+        }
+
+        public override void KeyPressed(KeyPayload payload)
+        {
+            if (bindingService.Reader == null)
+            {
+                StreamDeckCommon.ForceStop = true;
+                return;
+            }
+
+            StreamDeckCommon.ForceStop = false;
+
+            RefreshRuntimeSettings(payload?.Settings);
+
+            if (!bindingService.TryGetBinding(settings.Function, out var action))
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, "HoldMacroAction: no binding found for selected function");
+                return;
+            }
+
+            var keyInfo = CommandTools.ConvertKeyString(action.Keyboard);
+            if (string.IsNullOrWhiteSpace(keyInfo))
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"HoldMacroAction: selected function '{settings.Function}' has no keyboard/mouse token to send");
+                return;
+            }
+
+            CancelAutoRelease(false);
+
+            isKeyDown = true;
+            activeKeyInfo = keyInfo;
+
+            Logger.Instance.LogMessage(TracingLevel.INFO, $"HoldMacroAction pressed: sending DOWN for '{settings.Function}' (holdUntilRelease={settings.HoldUntilRelease}, duration={settings.HoldDurationMs}ms)");
+
+            StreamDeckCommon.SendKeypressDown(keyInfo);
+            _ = Connection.SetStateAsync(1);
+
+            if (!settings.HoldUntilRelease)
+            {
+                var duration = Math.Max(0, Math.Min(settings.HoldDurationMs, MaxHoldDurationMs));
+                if (duration > 0)
+                {
+                    ScheduleAutoRelease(keyInfo, duration);
+                }
+            }
+        }
+
+        public override void KeyReleased(KeyPayload payload)
+        {
+            if (!isKeyDown && autoReleaseToken == null)
+            {
+                return;
+            }
+
+            CancelAutoRelease(true);
+
+            if (!string.IsNullOrWhiteSpace(activeKeyInfo))
+            {
+                Logger.Instance.LogMessage(TracingLevel.INFO, $"HoldMacroAction released: sending UP for '{settings.Function}'");
+                StreamDeckCommon.SendKeypressUp(activeKeyInfo);
+            }
+
+            isKeyDown = false;
+            activeKeyInfo = null;
+
+            _ = Connection.SetStateAsync(0);
+        }
+
+        public override void ReceivedSettings(ReceivedSettingsPayload payload)
+        {
+            if (payload.Settings != null)
+            {
+                Tools.AutoPopulateSettings(settings, payload.Settings);
+                ClampHoldDuration();
+            }
+        }
+
+        public override void Dispose()
+        {
+            CancelAutoRelease(false);
+            Connection.OnPropertyInspectorDidAppear -= Connection_OnPropertyInspectorDidAppear;
+            Connection.OnSendToPlugin -= Connection_OnSendToPlugin;
+            bindingService.KeyBindingsLoaded -= OnKeyBindingsLoaded;
+            base.Dispose();
+        }
+
+        private void ScheduleAutoRelease(string keyInfo, int duration)
+        {
+            CancelAutoRelease(false);
+            autoReleaseToken = new CancellationTokenSource();
+            var token = autoReleaseToken.Token;
+
+            Logger.Instance.LogMessage(TracingLevel.INFO, $"HoldMacroAction: scheduling auto-release in {duration}ms for '{settings.Function}'");
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(duration, token);
+
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    Logger.Instance.LogMessage(TracingLevel.INFO, $"HoldMacroAction: auto-releasing '{settings.Function}' after {duration}ms");
+                    StreamDeckCommon.SendKeypressUp(keyInfo);
+                }
+                catch (TaskCanceledException)
+                {
+                    Logger.Instance.LogMessage(TracingLevel.INFO, "HoldMacroAction: auto-release cancelled before completion");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Instance.LogMessage(TracingLevel.ERROR, $"HoldMacroAction: error during auto-release: {ex}");
+                }
+                finally
+                {
+                    isKeyDown = false;
+                    activeKeyInfo = null;
+                    _ = Connection.SetStateAsync(0);
+                    DisposeAutoReleaseToken();
+                }
+            }, token);
+        }
+
+        private void CancelAutoRelease(bool logCancellation)
+        {
+            if (autoReleaseToken == null)
+            {
+                return;
+            }
+
+            if (!autoReleaseToken.IsCancellationRequested)
+            {
+                autoReleaseToken.Cancel();
+
+                if (logCancellation)
+                {
+                    Logger.Instance.LogMessage(TracingLevel.INFO, "HoldMacroAction: cancelled scheduled auto-release due to button release");
+                }
+            }
+
+            DisposeAutoReleaseToken();
+        }
+
+        private void DisposeAutoReleaseToken()
+        {
+            autoReleaseToken?.Dispose();
+            autoReleaseToken = null;
+        }
+
+        private void ClampHoldDuration()
+        {
+            settings.HoldDurationMs = Math.Max(0, Math.Min(settings.HoldDurationMs, MaxHoldDurationMs));
+        }
+
+        private void RefreshRuntimeSettings(JObject settingsObj)
+        {
+            if (settingsObj == null)
+            {
+                return;
+            }
+
+            if (settingsObj.TryGetValue("holdDurationMs", out var durationToken) &&
+                int.TryParse(durationToken.ToString(), out var parsedDuration))
+            {
+                settings.HoldDurationMs = Math.Max(0, Math.Min(parsedDuration, MaxHoldDurationMs));
+            }
+
+            if (settingsObj.TryGetValue("holdUntilRelease", out var holdUntilReleaseToken) &&
+                bool.TryParse(holdUntilReleaseToken.ToString(), out var holdUntilRelease))
+            {
+                settings.HoldUntilRelease = holdUntilRelease;
+            }
+        }
+
+        private void Connection_OnPropertyInspectorDidAppear(object sender, EventArgs e)
+        {
+            UpdatePropertyInspector();
+        }
+
+        private void Connection_OnSendToPlugin(object sender, EventArgs e)
+        {
+            var payload = e.ExtractPayload();
+
+            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            {
+                UpdatePropertyInspector();
+            }
+        }
+
+        private void OnKeyBindingsLoaded(object sender, EventArgs e)
+        {
+            UpdatePropertyInspector();
+        }
+
+        private void UpdatePropertyInspector()
+        {
+            if (bindingService.Reader == null)
+            {
+                return;
+            }
+
+            PropertyInspectorMessenger.SendFunctionsAsync(Connection);
+        }
+    }
+}

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -1,0 +1,258 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport"
+          content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+    <title>Star Citizen – Hold Macro</title>
+
+    <link rel="stylesheet" href="../sdpi.css">
+    <link rel="stylesheet" href="../jquery.highlight-within-textarea.css">
+
+    <script src="../sdtools.common.js"></script>
+    <script src="../jquery-3.3.1.min.js"></script>
+    <script src="../jquery.highlight-within-textarea.js"></script>
+
+    <style>
+        .no-results {
+            padding: 10px;
+            color: #999;
+            font-style: italic;
+            text-align: center;
+        }
+        .hidden {
+            display: none !important;
+        }
+        .note {
+            font-size: 11px;
+            color: #999;
+            margin-top: 4px;
+            line-height: 1.4;
+        }
+    </style>
+</head>
+
+<body>
+<div class="sdpi-wrapper">
+
+    <!-- SEARCH -->
+    <div class="sdpi-item">
+        <div class="sdpi-item-label">Search</div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
+        <div class="sdpi-item-value"
+             id="searchResults"
+             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+    </div>
+
+    <!-- FUNCTION -->
+    <div class="sdpi-item">
+        <div class="sdpi-item-label">Function</div>
+        <select class="sdpi-item-value select sdProperty"
+                id="function"
+                oninput="setSettings()"
+                onchange="setSettings()">
+            <option value="">Loading Star Citizen functions...</option>
+        </select>
+    </div>
+
+    <!-- HOLD UNTIL RELEASE -->
+    <div class="sdpi-item">
+        <div class="sdpi-item-label">Hold Mode</div>
+        <div class="sdpi-item-value">
+            <label for="holdUntilRelease" class="sdpi-item-label" style="width: auto;">
+                <input type="checkbox"
+                       class="sdProperty"
+                       id="holdUntilRelease"
+                       oninput="setSettings(); toggleDuration();"
+                       onchange="setSettings(); toggleDuration();">
+                Hold until release
+            </label>
+        </div>
+    </div>
+
+    <!-- HOLD DURATION -->
+    <div class="sdpi-item" id="durationRow">
+        <div class="sdpi-item-label">Hold duration (ms)</div>
+        <input type="number"
+               class="sdpi-item-value sdProperty"
+               id="holdDurationMs"
+               min="0"
+               max="60000"
+               step="50"
+               oninput="validateDuration(); setSettings();"
+               onchange="validateDuration(); setSettings();">
+    </div>
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value note">
+            If unchecked, the key will auto-release after the duration. Max 60,000ms.
+        </div>
+    </div>
+
+    <div class="sdpi-item no-results hidden" id="noResults">
+        No functions match your search.
+    </div>
+
+    <div class="sdpi-item">
+        <div class="sdpi-item-label"></div>
+        <div class="sdpi-item-value note">
+            Images are managed by Stream Deck (State 0 = idle, State 1 = held). Supports keyboard and mouse tokens.
+        </div>
+    </div>
+
+</div>
+
+<script>
+    const MAX_DURATION = 60000;
+    let allOptions = [];
+    let functionsLoaded = false;
+    let savedFunctionValue = null;
+
+    /* Preserve selected function if payload arrives before functions list */
+    const originalLoadConfiguration = loadConfiguration;
+    loadConfiguration = function (payload) {
+        if (payload && payload.function !== undefined) {
+            savedFunctionValue = payload.function;
+        }
+        originalLoadConfiguration(payload);
+        toggleDuration();
+
+        if (functionsLoaded && savedFunctionValue) {
+            const sel = document.getElementById('function');
+            if (sel) sel.value = savedFunctionValue;
+        }
+    };
+
+    function populateDropdown(functions) {
+        const select = document.getElementById('function');
+        select.innerHTML = '';
+        allOptions = [];
+
+        const empty = document.createElement('option');
+        empty.value = '';
+        empty.textContent = '-- Select a function --';
+        select.appendChild(empty);
+
+        functions.forEach(group => {
+            const optgroup = document.createElement('optgroup');
+            optgroup.label = group.label;
+
+            group.options.forEach(opt => {
+                const option = document.createElement('option');
+                option.value = opt.value;
+                option.textContent = opt.text;
+                option.dataset.search = opt.searchText || opt.text.toLowerCase();
+
+                optgroup.appendChild(option);
+
+                allOptions.push({
+                    option,
+                    optgroup,
+                    search: option.dataset.search
+                });
+            });
+
+            select.appendChild(optgroup);
+        });
+
+        functionsLoaded = true;
+
+        if (savedFunctionValue) {
+            select.value = savedFunctionValue;
+        }
+
+        filterOptions();
+    }
+
+    function filterOptions() {
+        if (!functionsLoaded) return;
+
+        const term = document.getElementById('functionSearch').value.toLowerCase().trim();
+        const noResults = document.getElementById('noResults');
+        const searchResults = document.getElementById('searchResults');
+
+        let visibleGroups = 0;
+
+        allOptions.forEach(o => {
+            const visible = !term || o.search.includes(term);
+            o.option.style.display = visible ? '' : 'none';
+        });
+
+        document.querySelectorAll('#function optgroup').forEach(group => {
+            const hasVisible = Array.from(group.children)
+                .some(o => o.style.display !== 'none');
+
+            group.style.display = hasVisible ? '' : 'none';
+            if (hasVisible) visibleGroups++;
+        });
+
+        noResults.classList.toggle('hidden', visibleGroups > 0);
+        searchResults.textContent = term
+            ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
+            : '';
+    }
+
+    function validateDuration() {
+        const input = document.getElementById('holdDurationMs');
+        if (!input) return;
+        const parsed = parseInt(input.value || '0', 10);
+        if (isNaN(parsed)) {
+            input.value = 0;
+            return;
+        }
+        input.value = Math.min(Math.max(parsed, 0), MAX_DURATION);
+    }
+
+    function toggleDuration() {
+        const checkbox = document.getElementById('holdUntilRelease');
+        const row = document.getElementById('durationRow');
+        if (!checkbox || !row) return;
+        row.classList.toggle('hidden', checkbox.checked);
+    }
+
+    /* Hook into websocket to receive function list */
+    document.addEventListener('websocketCreate', function () {
+        const originalOnMessage = websocket.onmessage;
+
+        websocket.onmessage = function (evt) {
+            const jsonObj = JSON.parse(evt.data);
+
+            if (jsonObj.event === 'sendToPropertyInspector'
+                && jsonObj.payload
+                && jsonObj.payload.functionsLoaded) {
+
+                populateDropdown(jsonObj.payload.functions);
+            }
+
+            if (originalOnMessage) {
+                originalOnMessage.call(this, evt);
+            }
+        };
+    });
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.getElementById('functionSearch')
+            .addEventListener('input', function () {
+                clearTimeout(this.searchTimeout);
+                this.searchTimeout = setTimeout(filterOptions, 150);
+            });
+
+        document.getElementById('function')
+            .addEventListener('change', function () {
+                document.getElementById('functionSearch').value = '';
+                document.getElementById('searchResults').textContent = '';
+            });
+
+        toggleDuration();
+    });
+</script>
+
+</body>
+</html>

--- a/starcitizen/manifest.json
+++ b/starcitizen/manifest.json
@@ -98,6 +98,27 @@
       "PropertyInspectorPath": "PropertyInspector/StarCitizen/Repeataction.html"
     },
     {
+      "Icon": "Images/HoldMacroAction0",
+      "Name": "Hold Macro",
+      "Controllers": ["Keypad"],
+      "States": [
+        {
+          "Image": "Images/HoldMacroAction0",
+          "TitleAlignment": "bottom",
+          "FontSize": "8"
+        },
+        {
+          "Image": "Images/HoldMacroAction1",
+          "TitleAlignment": "bottom",
+          "FontSize": "8"
+        }
+      ],
+      "SupportedInMultiActions": true,
+      "Tooltip": "Hold to send key/mouse down, release manually or after a set duration",
+      "UUID": "com.ltmajor42.starcitizen.holdmacro",
+      "PropertyInspectorPath": "PropertyInspector/StarCitizen/HoldMacroAction.html"
+    },
+    {
       "Icon": "Images/ActionDelay0",
       "Name": "Action Delay",
       "Controllers": ["Keypad"],

--- a/starcitizen/starcitizen.csproj
+++ b/starcitizen/starcitizen.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Audio\CachedSound.cs" />
     <Compile Include="Audio\CachedSoundSampleProvider.cs" />
     <Compile Include="Buttons\ActionDelay.cs" />
+    <Compile Include="Buttons\HoldMacroAction.cs" />
     <Compile Include="Buttons\CosmeticKey.cs" />
     <Compile Include="Buttons\FunctionListBuilder.cs" />
     <Compile Include="Buttons\DualAction.cs" />
@@ -281,6 +282,12 @@
     <Content Include="Images\Dualaction1.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Images\HoldMacroAction0.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Images\HoldMacroAction1.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Images\icon%402x.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -357,6 +364,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="PropertyInspector\StarCitizen\DualAction.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PropertyInspector\StarCitizen\HoldMacroAction.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="PropertyInspector\StarCitizen\Repeataction.html">


### PR DESCRIPTION
## Summary
- add a Hold Macro Stream Deck action that sends a down event immediately and optionally auto-releases after a configured duration
- provide Property Inspector UI with hold-until-release toggle, duration cap, and updated manifest/icon wiring
- document the new action and usage tips in the README

## Testing
- dotnet build starcitizen.sln *(fails: `dotnet` CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955bf6151e0832d81bb5af683b86506)