### PR TITLE
Allow hold macro to repeat mouse wheel scrolls

### DIFF
--- a/starcitizen/Buttons/HoldMacroAction.cs
+++ b/starcitizen/Buttons/HoldMacroAction.cs
@@ -227,7 +227,15 @@ namespace starcitizen.Buttons
 
         private void StartRepeat(string keyInfo)
         {
-            if (string.IsNullOrWhiteSpace(keyInfo) || ContainsMouseToken(keyInfo))
+            if (string.IsNullOrWhiteSpace(keyInfo))
+            {
+                return;
+            }
+
+            var containsWheelToken = ContainsMouseWheelToken(keyInfo);
+
+            // Do not repeat non-wheel mouse actions to avoid spamming button presses.
+            if (!containsWheelToken && ContainsMouseToken(keyInfo))
             {
                 return;
             }
@@ -284,6 +292,23 @@ namespace starcitizen.Buttons
             {
                 var token = match.Value.Replace("{", string.Empty).Replace("}", string.Empty);
                 if (MouseTokenHelper.TryNormalize(token, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool ContainsMouseWheelToken(string keyInfo)
+        {
+            var matches = Regex.Matches(keyInfo, CommandTools.REGEX_SUB_COMMAND);
+
+            foreach (Match match in matches)
+            {
+                var token = match.Value.Replace("{", string.Empty).Replace("}", string.Empty);
+                if (MouseTokenHelper.TryNormalize(token, out var normalized) &&
+                    normalized.StartsWith("mwheel", StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- allow HoldMacro repeat logic to include mouse wheel tokens so holding scrolls can generate continuous scrolling
- keep other mouse actions from repeating while adding a helper that detects wheel tokens

## Testing
- dotnet build starcitizen.sln *(fails: dotnet CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c7fe50ec832d83a81d10a9bd5f3f)