### PR TITLE
Add property inspector keybind refresh control

### DIFF
--- a/starcitizen/Buttons/ActionDelay.cs
+++ b/starcitizen/Buttons/ActionDelay.cs
@@ -502,15 +502,22 @@ namespace starcitizen.Buttons
             try
             {
                 var payload = e.ExtractPayload();
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
                 if (payload != null && payload.ContainsKey("property_inspector") &&
                     payload["property_inspector"]?.ToString() == "propertyInspectorConnected")
                 {
                     UpdatePropertyInspector();
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // ignore malformed payloads
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Error processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/Dial.cs
+++ b/starcitizen/Buttons/Dial.cs
@@ -305,10 +305,24 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/DualAction.cs
+++ b/starcitizen/Buttons/DualAction.cs
@@ -126,11 +126,25 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-
-            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/HoldMacroAction.cs
+++ b/starcitizen/Buttons/HoldMacroAction.cs
@@ -349,11 +349,25 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-
-            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/Momentary.cs
+++ b/starcitizen/Buttons/Momentary.cs
@@ -213,11 +213,25 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-
-            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/Repeataction.cs
+++ b/starcitizen/Buttons/Repeataction.cs
@@ -203,12 +203,26 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-
-            if (payload != null && payload["property_inspector"] != null &&
-                payload["property_inspector"].ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload != null && payload["property_inspector"] != null &&
+                    payload["property_inspector"].ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/Buttons/StateMemory.cs
+++ b/starcitizen/Buttons/StateMemory.cs
@@ -269,11 +269,25 @@ namespace starcitizen.Buttons
 
         private void Connection_OnSendToPlugin(object sender, EventArgs e)
         {
-            var payload = e.ExtractPayload();
-
-            if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+            try
             {
-                UpdatePropertyInspector();
+                var payload = e.ExtractPayload();
+
+                if (payload != null && payload.TryGetValue("piEvent", out var piEvent) &&
+                    piEvent?.ToString() == "refreshKeybinds")
+                {
+                    bindingService.QueueReload();
+                    return;
+                }
+
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                {
+                    UpdatePropertyInspector();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.WARN, $"Failed processing PI payload: {ex.Message}");
             }
         }
 

--- a/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
@@ -21,6 +21,8 @@
     .note { font-size: 11px; color: #999; line-height: 1.4; }
     .hidden { display: none; }
     .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
+    .search-row { display: flex; gap: 6px; align-items: center; }
+    .refresh-button { min-width: 48px; padding: 6px 10px; }
   </style>
 </head>
 
@@ -29,11 +31,20 @@
 
   <div class="sdpi-item">
     <div class="sdpi-item-label">Search</div>
-    <input type="text"
-           class="sdpi-item-value"
-           id="functionSearch"
-           placeholder="Type to search functions..."
-           autocomplete="off">
+    <div class="sdpi-item-value search-row">
+      <input type="text"
+             class="sdpi-item-value"
+             id="functionSearch"
+             placeholder="Type to search functions..."
+             autocomplete="off"
+             style="flex: 1;">
+      <button class="sdpi-item-value refresh-button"
+              type="button"
+              onclick="refreshKeybinds(this)"
+              title="Reload Star Citizen keybinds">
+        ⟳
+      </button>
+    </div>
     <div class="sdpi-item-value" id="searchResults"
          style="font-size: 11px; color: #999; margin-top: 4px;"></div>
   </div>
@@ -230,6 +241,21 @@
 
     setSettings({ clickSound: '' });
     updateClearSoundVisibility();
+  }
+
+  function refreshKeybinds(button) {
+    if (!button || button.disabled) return;
+
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = 'Refreshing…';
+
+    sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+    setTimeout(() => {
+      button.disabled = false;
+      button.textContent = originalText;
+    }, 800);
   }
 
   document.addEventListener('websocketCreate', function () {

--- a/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
@@ -26,6 +26,15 @@
         .hidden {
             display: none !important;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -35,11 +44,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -186,6 +204,21 @@
 
         setSettings({ clickSound: '' });
         updateClearSoundVisibility();
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     function updateClearSoundVisibility() {

--- a/starcitizen/PropertyInspector/StarCitizen/Dial.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Dial.html
@@ -26,6 +26,15 @@
         .hidden {
             display: none !important;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -35,11 +44,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -212,6 +230,21 @@
         searchResults.textContent = term
             ? `Found ${count} group${count !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     document.addEventListener('websocketCreate', function () {

--- a/starcitizen/PropertyInspector/StarCitizen/DualAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/DualAction.html
@@ -26,6 +26,15 @@
         .hidden {
             display: none !important;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -35,11 +44,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -219,6 +237,21 @@
         searchResults.textContent = term
             ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     /* CLEAR SOUND HANDLER */

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -32,6 +32,15 @@
             margin-top: 4px;
             line-height: 1.4;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -41,11 +50,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -176,6 +194,21 @@
         searchResults.textContent = term
             ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     /* Hook into websocket to receive function list */

--- a/starcitizen/PropertyInspector/StarCitizen/Momentary.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Momentary.html
@@ -26,6 +26,15 @@
         .hidden {
             display: none !important;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -35,11 +44,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -184,6 +202,21 @@
         searchResults.textContent = term
             ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     /* CLEAR SOUND HANDLER */

--- a/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
@@ -32,6 +32,15 @@
             margin-top: 4px;
             line-height: 1.4;
         }
+        .search-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+        .refresh-button {
+            min-width: 48px;
+            padding: 6px 10px;
+        }
     </style>
 </head>
 
@@ -41,11 +50,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -178,6 +196,21 @@
         searchResults.textContent = term
             ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     /* Hook into websocket to receive function list */

--- a/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
+++ b/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
@@ -23,6 +23,8 @@
         .compact { margin-top: 0; }
         .inline-row { display: flex; align-items: center; gap: 10px; }
         .small-btn { padding: 4px 8px; height: 26px; }
+        .search-row { display: flex; gap: 6px; align-items: center; }
+        .refresh-button { min-width: 48px; padding: 6px 10px; }
     </style>
 </head>
 
@@ -32,11 +34,20 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions."
-               autocomplete="off">
+        <div class="sdpi-item-value search-row">
+            <input type="text"
+                   class="sdpi-item-value"
+                   id="functionSearch"
+                   placeholder="Type to search functions."
+                   autocomplete="off"
+                   style="flex: 1;">
+            <button class="sdpi-item-value refresh-button"
+                    type="button"
+                    onclick="refreshKeybinds(this)"
+                    title="Reload Star Citizen keybinds">
+                ⟳
+            </button>
+        </div>
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>
@@ -247,6 +258,21 @@
         searchResults.textContent = term
             ? `Found ${visibleGroups} group${visibleGroups !== 1 ? 's' : ''}`
             : '';
+    }
+
+    function refreshKeybinds(button) {
+        if (!button || button.disabled) return;
+
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Refreshing…';
+
+        sendValueToPlugin('refreshKeybinds', 'piEvent');
+
+        setTimeout(() => {
+            button.disabled = false;
+            button.textContent = originalText;
+        }, 800);
     }
 
     function clearSound(inputId) {

--- a/starcitizen/SC/SCDefaultProfile.cs
+++ b/starcitizen/SC/SCDefaultProfile.cs
@@ -58,9 +58,10 @@ namespace SCJMapper_V2.SC
 
             if (File.Exists(mFile))
             {
-                using (var sr = new StreamReader(mFile))
+                using (var stream = new FileStream(mFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                using (var reader = new StreamReader(stream))
                 {
-                    return sr.ReadToEnd();
+                    return reader.ReadToEnd();
                 }
             }
 


### PR DESCRIPTION
## Summary
- add a refresh control to each Property Inspector to request a keybind reload without restarting the plugin
- handle the new refreshKeybinds message in button actions to queue a KeyBindingService reload
- open actionmaps.xml with read/write sharing so refreshes succeed while Star Citizen is running

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ccfa2050832d84fe89cc2631b5ca)