### PR TITLE
Improve actionmaps refresh path resolution

### DIFF
--- a/starcitizen/Core/KeyBindingService.cs
+++ b/starcitizen/Core/KeyBindingService.cs
@@ -132,10 +132,11 @@ namespace starcitizen.Core
         {
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                var actionmaps = SCDefaultProfile.ActionMaps();
+                var actionmaps = SCDefaultProfile.ActionMaps(out var actionmapsPath);
                 if (string.IsNullOrEmpty(actionmaps))
                 {
                     // No actionmaps.xml (or empty) => nothing to apply
+                    PluginLog.Warn($"actionmaps.xml missing or empty at '{actionmapsPath ?? "(unknown)"}'. Keeping previous bindings.");
                     return true;
                 }
 

--- a/starcitizen/SC/SCDefaultProfile.cs
+++ b/starcitizen/SC/SCDefaultProfile.cs
@@ -49,21 +49,25 @@ namespace SCJMapper_V2.SC
         /// </summary>
         public static string ActionMaps()
         {
-            var profilePath = SCPath.SCClientProfilePath;
-            if (string.IsNullOrWhiteSpace(profilePath))
+            return ActionMaps(out _);
+        }
+
+        public static string ActionMaps(out string resolvedPath)
+        {
+            resolvedPath = SCPath.ResolveActionMapsPath();
+            if (string.IsNullOrWhiteSpace(resolvedPath))
             {
-                Logger.Instance.LogMessage(TracingLevel.WARN, "SCClientProfilePath is empty/null.");
+                Logger.Instance.LogMessage(TracingLevel.WARN, "Could not resolve actionmaps.xml path.");
                 return "";
             }
 
-            string mFile = Path.Combine(profilePath, "actionmaps.xml");
-            Logger.Instance.LogMessage(TracingLevel.INFO, mFile);
+            Logger.Instance.LogMessage(TracingLevel.INFO, resolvedPath);
 
-            if (File.Exists(mFile))
+            if (File.Exists(resolvedPath))
             {
                 try
                 {
-                    using (var stream = new FileStream(mFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                    using (var stream = new FileStream(resolvedPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                     using (var reader = new StreamReader(stream))
                     {
                         return reader.ReadToEnd();

--- a/starcitizen/SC/SCPath.cs
+++ b/starcitizen/SC/SCPath.cs
@@ -788,6 +788,46 @@ namespace SCJMapper_V2.SC
             }
         }
 
+        /// <summary>
+        /// Returns the best-effort path to the current actionmaps.xml file.
+        /// Tries the expected profile folder first, then falls back to scanning
+        /// the USER tree (handles non-default profile folders or renamed paths).
+        /// </summary>
+        public static string ResolveActionMapsPath()
+        {
+            var profilePath = SCClientProfilePath;
+            if (!string.IsNullOrWhiteSpace(profilePath))
+            {
+                var candidate = Path.Combine(profilePath, "actionmaps.xml");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            var userRoot = SCClientUSERPath;
+            if (!string.IsNullOrWhiteSpace(userRoot) && Directory.Exists(userRoot))
+            {
+                try
+                {
+                    var candidates = Directory.EnumerateFiles(userRoot, "actionmaps.xml", SearchOption.AllDirectories)
+                                              .OrderByDescending(File.GetLastWriteTimeUtc)
+                                              .ToArray();
+
+                    if (candidates.Length > 0)
+                    {
+                        return candidates[0];
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Instance.LogMessage(TracingLevel.DEBUG, $"ResolveActionMapsPath scan failed: {ex.Message}");
+                }
+            }
+
+            return "";
+        }
+
 
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add fallback resolution for actionmaps.xml so refresh can find alternate profile locations
- surface clearer logging when actionmaps.xml is missing or empty during refresh attempts

## Testing
- dotnet build starcitizen.sln *(fails: dotnet SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955d987cfa8832dbacdc4eec362dad8)