### PR TITLE
Improve search layout in ActionDelay inspector

### DIFF
--- a/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/PropertyInspector/StarCitizen/ActionDelay.html
@@ -31,6 +31,19 @@
             color: #999;
             margin-top: 4px;
         }
+        .search-container {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            width: 100%;
+        }
+        .search-container input[type="text"] {
+            width: 100%;
+        }
+        .search-status {
+            font-size: 11px;
+            color: #999;
+        }
     </style>
 </head>
 
@@ -40,14 +53,13 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <input type="text"
-               class="sdpi-item-value"
-               id="functionSearch"
-               placeholder="Type to search functions..."
-               autocomplete="off">
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="sdpi-item-value search-container">
+            <input type="text"
+                   id="functionSearch"
+                   placeholder="Type to search functions..."
+                   autocomplete="off">
+            <div class="search-status" id="searchResults"></div>
+        </div>
     </div>
 
     <!-- FUNCTION -->


### PR DESCRIPTION
## Summary
- wrap the function search input and its status text in a full-width container to avoid a narrow field
- add supporting styles to keep the search field and helper text aligned after removing the refresh button

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e8abacf0832dbca11ff90107b408)