### PR TITLE
Align search inputs with dropdown height

### DIFF
--- a/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
@@ -21,7 +21,18 @@
     .note { font-size: 11px; color: #999; line-height: 1.4; }
     .hidden { display: none; }
     .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
-    .search-row { display: flex; gap: 6px; align-items: center; }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
   </style>
 </head>
 
@@ -35,8 +46,7 @@
              class="sdpi-item-value"
              id="functionSearch"
              placeholder="Type to search functions..."
-             autocomplete="off"
-             style="flex: 1;">
+             autocomplete="off">
     </div>
     <div class="sdpi-item-value" id="searchResults"
          style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
@@ -26,11 +26,18 @@
         .hidden {
             display: none !important;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -45,8 +52,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/Dial.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Dial.html
@@ -26,11 +26,18 @@
         .hidden {
             display: none !important;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -45,8 +52,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/DualAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/DualAction.html
@@ -26,11 +26,18 @@
         .hidden {
             display: none !important;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -45,8 +52,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -32,11 +32,18 @@
             margin-top: 4px;
             line-height: 1.4;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -51,8 +58,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/Momentary.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Momentary.html
@@ -26,11 +26,18 @@
         .hidden {
             display: none !important;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -45,8 +52,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
@@ -32,11 +32,18 @@
             margin-top: 4px;
             line-height: 1.4;
         }
-        .search-row {
-            display: flex;
-            gap: 6px;
-            align-items: center;
-        }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -51,8 +58,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions..."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"

--- a/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
+++ b/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
@@ -23,7 +23,18 @@
         .compact { margin-top: 0; }
         .inline-row { display: flex; align-items: center; gap: 10px; }
         .small-btn { padding: 4px 8px; height: 26px; }
-        .search-row { display: flex; gap: 6px; align-items: center; }
+    .search-row {
+        display: flex;
+        gap: 6px;
+        align-items: stretch;
+        min-height: 23px;
+    }
+    .search-row input.sdpi-item-value {
+        flex: 1;
+        height: 100%;
+        min-height: 23px;
+        box-sizing: border-box;
+    }
     </style>
 </head>
 
@@ -38,8 +49,7 @@
                    class="sdpi-item-value"
                    id="functionSearch"
                    placeholder="Type to search functions."
-                   autocomplete="off"
-                   style="flex: 1;">
+                   autocomplete="off">
         </div>
         <div class="sdpi-item-value"
              id="searchResults"


### PR DESCRIPTION
## Summary
- adjust property inspector search row styling to stretch search inputs to match dropdown height
- remove inline flex styling in favor of shared CSS so search boxes fill their containers consistently

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e98bf294832d833c9a2936384804)