### PR TITLE
Sync keyboard field with mouse rebinds

### DIFF
--- a/starcitizen/SC/DProfileReader.cs
+++ b/starcitizen/SC/DProfileReader.cs
@@ -291,7 +291,7 @@ namespace SCJMapper_V2.SC
                 {
                     var normalized = NormalizeMouseBinding(input);
                     currentAction.Mouse = normalized;
-                    if (string.IsNullOrWhiteSpace(currentAction.Keyboard))
+                    if (string.IsNullOrWhiteSpace(currentAction.Keyboard) || MouseTokenHelper.IsMouseLike(currentAction.Keyboard))
                     {
                         currentAction.Keyboard = normalized;
                     }
@@ -446,7 +446,8 @@ namespace SCJMapper_V2.SC
                                 {
                                     var normalized = NormalizeMouseBinding(input);
                                     map.Actions[actionName].Mouse = normalized;
-                                    if (string.IsNullOrWhiteSpace(map.Actions[actionName].Keyboard))
+                                    if (string.IsNullOrWhiteSpace(map.Actions[actionName].Keyboard) ||
+                                        MouseTokenHelper.IsMouseLike(map.Actions[actionName].Keyboard))
                                     {
                                         map.Actions[actionName].Keyboard = normalized;
                                     }
@@ -455,6 +456,11 @@ namespace SCJMapper_V2.SC
                                 else if (SCPath.TreatBlankRebindAsUnbound)
                                 {
                                     map.Actions[actionName].Mouse = "";
+                                    if (string.IsNullOrWhiteSpace(map.Actions[actionName].Keyboard) ||
+                                        MouseTokenHelper.IsMouseLike(map.Actions[actionName].Keyboard))
+                                    {
+                                        map.Actions[actionName].Keyboard = "";
+                                    }
                                     map.Actions[actionName].MouseOverRule = true;
                                 }
                             }


### PR DESCRIPTION
## Summary
- update mouse rebind handling to refresh keyboard bindings when they mirror mouse inputs
- clear keyboard bindings alongside mouse unbinds to keep mouse actions consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ef8a009c832d8cf767d80cdd727a)