### PR TITLE
Align SC namespace with folder and include Zstd.Net dependency

### DIFF
--- a/starcitizen/Buttons/ActionKey.cs
+++ b/starcitizen/Buttons/ActionKey.cs
@@ -9,7 +9,7 @@ using BarRaider.SdTools.Events;
 using BarRaider.SdTools.Wrappers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using SCJMapper_V2.SC;
+using starcitizen.SC;
 using starcitizen.Core;
 
 // ReSharper disable StringLiteralTypo

--- a/starcitizen/Buttons/StateMemory.cs
+++ b/starcitizen/Buttons/StateMemory.cs
@@ -8,7 +8,7 @@ using BarRaider.SdTools.Events;
 using BarRaider.SdTools.Wrappers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using SCJMapper_V2.SC;
+using starcitizen.SC;
 using starcitizen.Core;
 
 namespace starcitizen.Buttons

--- a/starcitizen/Buttons/StreamDeckCommon.cs
+++ b/starcitizen/Buttons/StreamDeckCommon.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using WindowsInput;
 using WindowsInput.Native;
 using BarRaider.SdTools;
-using SCJMapper_V2.SC;
+using starcitizen.SC;
 
 namespace starcitizen.Buttons
 {

--- a/starcitizen/CommandTools.cs
+++ b/starcitizen/CommandTools.cs
@@ -1,5 +1,5 @@
 ﻿using BarRaider.SdTools;
-using SCJMapper_V2.SC;
+using starcitizen.SC;
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/starcitizen/Core/KeyBindingService.cs
+++ b/starcitizen/Core/KeyBindingService.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Threading;
 using BarRaider.SdTools;
 using p4ktest.SC;
-using SCJMapper_V2.SC;
+using starcitizen.SC;
 
 namespace starcitizen.Core
 {

--- a/starcitizen/SC/DProfileReader.cs
+++ b/starcitizen/SC/DProfileReader.cs
@@ -8,7 +8,7 @@ using BarRaider.SdTools;
 using starcitizen;
 using TheUser = p4ktest.SC.TheUser;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
     public class DProfileReader
     {

--- a/starcitizen/SC/SCDefaultProfile.cs
+++ b/starcitizen/SC/SCDefaultProfile.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Threading;
 using BarRaider.SdTools;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
     /// <summary>
     /// Finds and returns the DefaultProfile from SC GameData.pak

--- a/starcitizen/SC/SCFile.cs
+++ b/starcitizen/SC/SCFile.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
   /// <summary>
   /// One SC asset file

--- a/starcitizen/SC/SCLocale.cs
+++ b/starcitizen/SC/SCLocale.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
   class SCLocale : Dictionary<string,string>
   {

--- a/starcitizen/SC/SCPath.cs
+++ b/starcitizen/SC/SCPath.cs
@@ -12,7 +12,7 @@ using TheUser = p4ktest.SC.TheUser;
 
 //using SCJMapper_V2.Translation;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
     /// <summary>
     /// Find the SC pathes and folders using multiple detection methods

--- a/starcitizen/SC/SCUiText.cs
+++ b/starcitizen/SC/SCUiText.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using p4ktest.SC;
 using SCJMapper_V2.p4kFile;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
     sealed class SCUiText
     {

--- a/starcitizen/SC/SCfiles.cs
+++ b/starcitizen/SC/SCfiles.cs
@@ -13,7 +13,7 @@ using BarRaider.SdTools;
 using p4ktest;
 using TheUser = p4ktest.SC.TheUser;
 
-namespace SCJMapper_V2.SC
+namespace starcitizen.SC
 {
     /// <summary>
     /// Manages all SC files from Pak

--- a/starcitizen/p4kFile/p4kFileHeader.cs
+++ b/starcitizen/p4kFile/p4kFileHeader.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
-using ZstdNet;
+using Zstd.Net;
 
 namespace SCJMapper_V2.p4kFile
 {

--- a/starcitizen/starcitizen.csproj
+++ b/starcitizen/starcitizen.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.SharpZipLib\ICSharpCode.SharpZipLib.csproj" />
+    <ProjectReference Include="..\Zstd.Net\Zstd.Net.csproj" />
     <ProjectReference Include="..\InputSimulatorPlus\WindowsInput\WindowsInput.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- update SC files and consumers to use the starcitizen.SC namespace to match folder structure
- reference the local Zstd.Net project and correct the Zstd namespace alias in p4kFileHeader

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955fcceca58832da9f03b0b9c00c650)