### PR TITLE
Fix p4k type references and decompression handling

### DIFF
--- a/starcitizen/SC/SCfiles.cs
+++ b/starcitizen/SC/SCfiles.cs
@@ -89,12 +89,12 @@ namespace starcitizen.SC
             {
                 try
                 {
-                    var PD = new p4kFile.p4kDirectory();
+                    var PD = new p4kDirectory();
                     // Multiple copies of defaultProfile.xml can exist inside Data.p4k.
                     // Picking the "first match" is unstable and can lead to missing/incorrect bindings.
                     var candidates = PD.ScanDirectoryForAllEndsWith(SCPath.SCData_p4k, SCDefaultProfile.DefaultProfileName);
 
-                    p4kFile.p4kFile p4K = null;
+                    p4kFile p4K = null;
                     if (candidates != null && candidates.Count > 0)
                     {
                         foreach (var c in candidates)
@@ -171,8 +171,8 @@ namespace starcitizen.SC
                 try
                 {
                     var PD = new p4kDirectory();
-                    IList<p4kFile.p4kFile> fileList = PD.ScanDirectoryContaining(SCPath.SCData_p4k, @"\global.ini");
-                    foreach (p4kFile.p4kFile file in fileList)
+                    IList<p4kFile> fileList = PD.ScanDirectoryContaining(SCPath.SCData_p4k, @"\global.ini");
+                    foreach (p4kFile file in fileList)
                     {
                         string retVal = "";
                         string lang = Path.GetFileNameWithoutExtension(Path.GetDirectoryName(file.Filename));

--- a/starcitizen/p4kFile/p4kFileHeader.cs
+++ b/starcitizen/p4kFile/p4kFileHeader.cs
@@ -175,17 +175,19 @@ namespace SCJMapper_V2.p4kFile
       byte[] decompFile = null;
       if ( m_item.CompressionMethod == 0x64 ) {
         // this indicates p4k ZStd compression
-        using ( var decompressor = new Decompressor( ) ) {
-          try {
-            decompFile = decompressor.Unwrap( fileBytes );
+        try {
+          using ( var compressedStream = new MemoryStream( fileBytes ) )
+          using ( var decompressor = new InputStream( compressedStream, true ) )
+          using ( var output = new MemoryStream( ) ) {
+            decompressor.CopyTo( output );
+            decompFile = output.ToArray( );
             return decompFile;
           }
-          catch ( ZstdException e ) {
-            Console.WriteLine( "ZStd - Cannot decode file: " + m_filename );
-            Console.WriteLine( "Error: " + e.Message );
-            //Console.ReadLine();
-            return  new byte[] { };
-          }
+        }
+        catch ( ZStdException e ) {
+          Console.WriteLine( "ZStd - Cannot decode file: " + m_filename );
+          Console.WriteLine( "Error: " + e.Message );
+          return  new byte[] { };
         }
       }
       else {


### PR DESCRIPTION
## Summary
- fix p4k type references in SC file loader to match actual namespace types
- replace missing Decompressor usage with Zstd.Net InputStream and correct exception type when reading p4k entries

## Testing
- dotnet build starcitizen.sln (fails: dotnet not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955fe3de684832da32111b2c3272ab7)