### PR TITLE
Replace BinaryFormatter and annotate Windows-only APIs

### DIFF
--- a/starcitizen/Audio/AudioPlaybackEngine .cs
+++ b/starcitizen/Audio/AudioPlaybackEngine .cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 
 namespace starcitizen
 {
+    [SupportedOSPlatform("windows")]
     class AudioPlaybackEngine : IDisposable
     {
         private readonly IWavePlayer outputDevice;

--- a/starcitizen/Audio/CachedSound.cs
+++ b/starcitizen/Audio/CachedSound.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using NAudio.Wave;
 
 namespace starcitizen
 {
+    [SupportedOSPlatform("windows")]
     class CachedSound
     {
         public float[] AudioData { get; private set; }

--- a/starcitizen/SC/SCPath.cs
+++ b/starcitizen/SC/SCPath.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.IO;
 using BarRaider.SdTools;
 using Microsoft.Win32;
+using System.Runtime.Versioning;
 using p4ktest;
 using TheUser = p4ktest.SC.TheUser;
 
@@ -17,6 +18,7 @@ namespace starcitizen.SC
     /// <summary>
     /// Find the SC pathes and folders using multiple detection methods
     /// </summary>
+    [SupportedOSPlatform("windows")]
     class SCPath
     {
         private static readonly string[] KNOWN_REGISTRY_KEYS = new[]

--- a/starcitizen/SC/SCfiles.cs
+++ b/starcitizen/SC/SCfiles.cs
@@ -4,12 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using SCJMapper_V2.CryXMLlib;
 using SCJMapper_V2.p4kFile;
 using System.IO.Compression;
 using BarRaider.SdTools;
+using System.Text.Json;
 using p4ktest;
 using TheUser = p4ktest.SC.TheUser;
 
@@ -24,6 +23,10 @@ namespace starcitizen.SC
         private SCFile m_pakFile; // no content, carries only the filedate
         private SCFile m_defProfile;
         private Dictionary<string, SCFile> m_langFiles;
+        private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         // Singleton
         private static readonly Lazy<SCFiles> m_lazy = new Lazy<SCFiles>(() => new SCFiles());
@@ -263,11 +266,13 @@ namespace starcitizen.SC
                     {
                         using (var gZipStream = new GZipStream(stream, CompressionMode.Decompress))
                         {
-                            BinaryFormatter binaryFormatter = new BinaryFormatter();
-                            obj = (SCFile) binaryFormatter.Deserialize(gZipStream);
+                            obj = JsonSerializer.Deserialize<SCFile>(gZipStream, s_jsonOptions);
                         }
-
-                        stream.Close();
+                        if (obj == null)
+                        {
+                            Logger.Instance.LogMessage(TracingLevel.WARN, $"LoadPack - unable to deserialize {file}");
+                            continue;
+                        }
                         if (obj.Filetype == SCFile.FileType.PakFile)
                         {
                             m_pakFile = obj;
@@ -324,11 +329,8 @@ namespace starcitizen.SC
                 {
                     using (var gZipStream = new GZipStream(stream, CompressionMode.Compress))
                     {
-                        BinaryFormatter binaryFormatter = new BinaryFormatter();
-                        binaryFormatter.Serialize(gZipStream, m_pakFile);
+                        JsonSerializer.Serialize(gZipStream, m_pakFile, s_jsonOptions);
                     }
-
-                    stream.Close();
                 }
 
                 if (m_defProfile.Filetype == SCFile.FileType.DefProfile)
@@ -339,11 +341,8 @@ namespace starcitizen.SC
                     {
                         using (var gZipStream = new GZipStream(stream, CompressionMode.Compress))
                         {
-                            BinaryFormatter binaryFormatter = new BinaryFormatter();
-                            binaryFormatter.Serialize(gZipStream, m_defProfile);
+                            JsonSerializer.Serialize(gZipStream, m_defProfile, s_jsonOptions);
                         }
-
-                        stream.Close();
                     }
 
                     File.WriteAllText(Path.Combine(p4ktest.SC.TheUser.FileStoreDir, m_defProfile.Filename),
@@ -359,11 +358,8 @@ namespace starcitizen.SC
                         {
                             using (var gZipStream = new GZipStream(stream, CompressionMode.Compress))
                             {
-                                BinaryFormatter binaryFormatter = new BinaryFormatter();
-                                binaryFormatter.Serialize(gZipStream, kv.Value);
+                                JsonSerializer.Serialize(gZipStream, kv.Value, s_jsonOptions);
                             }
-
-                            stream.Close();
                         }
                     }
                 }

--- a/starcitizen/p4kFile/p4kDirectory.cs
+++ b/starcitizen/p4kFile/p4kDirectory.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using ICSharpCode.SharpZipLib.Zip;
 
 
@@ -15,6 +16,7 @@ namespace SCJMapper_V2.p4kFile
   /// <summary>
   /// Limited Directory scanner for p4k files
   /// </summary>
+  [SupportedOSPlatform("windows")]
   public class p4kDirectory
   {
         //  4.3.6 Overall.ZIP file format:

--- a/starcitizen/p4kFile/p4kFileHeader.cs
+++ b/starcitizen/p4kFile/p4kFileHeader.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using Zstd.Net;
 
 namespace SCJMapper_V2.p4kFile
@@ -13,6 +14,7 @@ namespace SCJMapper_V2.p4kFile
   /// Represents a Fileheader entry in the p4k File
   /// seems to be a Zip64 based file and therefore using those headers
   /// </summary>
+  [SupportedOSPlatform("windows")]
   internal class p4kFileHeader : IDisposable
   {
 


### PR DESCRIPTION
## Summary
- replace BinaryFormatter serialization of cached Star Citizen files with System.Text.Json while maintaining gzip compression
- add Windows platform annotations to audio, registry, and p4k access classes to address CA1416 warnings

## Testing
- dotnet build starcitizen.sln *(fails: `dotnet` not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955fee8856c832d9f5a544b95660d06)