### PR TITLE
Add missing platform attribute namespace

### DIFF
--- a/starcitizen/SC/SCfiles.cs
+++ b/starcitizen/SC/SCfiles.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Versioning;
 using SCJMapper_V2.CryXMLlib;
 using SCJMapper_V2.p4kFile;
 using System.IO.Compression;


### PR DESCRIPTION
## Summary
- add System.Runtime.Versioning import so SupportedOSPlatform attribute resolves in SCFiles

## Testing
- dotnet build (fails: dotnet command not available in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69560178c51c832d97098f84b0cc4f1b)