### PR TITLE
Mark plugin assembly as Windows-only

### DIFF
--- a/starcitizen/Properties/AssemblyInfo.cs
+++ b/starcitizen/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.Versioning;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.1.9.0")]
 [assembly: AssemblyFileVersion("1.1.9.0")]
+
+[assembly: SupportedOSPlatform("windows")]


### PR DESCRIPTION
## Summary
- declare the plugin assembly as Windows-only to align with platform dependencies and silence CA1416 warnings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69567d6f9f08832d9d0eddabeefe0630)