### PR TITLE
Ensure property inspector inputs fill available width

### DIFF
--- a/starcitizen/PropertyInspector/sdpi.css
+++ b/starcitizen/PropertyInspector/sdpi.css
@@ -271,6 +271,13 @@ option {
   padding: 0px 4px 0px 4px;
 }
 
+.sdpi-item select.sdpi-item-value,
+.sdpi-item input.sdpi-item-value:not([type="radio"]):not([type="checkbox"]):not([type="file"]),
+.sdpi-item textarea.sdpi-item-value {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 
 .sdpi-item-group {
   padding: 0 !important;


### PR DESCRIPTION
## Summary
- ensure property inspector select/inputs/textarea elements span the full available width to align controls consistently

## Testing
- not run (UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695682a35e38832d9968fc0c0a194dd6)