### PR TITLE
Apply SPDI wrapper layout to Star Citizen property inspectors

### DIFF
--- a/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
@@ -21,18 +21,6 @@
     .note { font-size: 11px; color: #999; line-height: 1.4; }
     .hidden { display: none; }
     .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
   </style>
 </head>
 
@@ -41,13 +29,11 @@
 
   <div class="sdpi-item">
     <div class="sdpi-item-label">Search</div>
-    <div class="sdpi-item-value search-row">
-      <input type="text"
-             class="sdpi-item-value"
-             id="functionSearch"
-             placeholder="Type to search functions..."
-             autocomplete="off">
-    </div>
+    <input type="text"
+           class="sdpi-item-value"
+           id="functionSearch"
+           placeholder="Type to search functions..."
+           autocomplete="off">
     <div class="sdpi-item-value" id="searchResults"
          style="font-size: 11px; color: #999; margin-top: 4px;"></div>
   </div>

--- a/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
@@ -26,18 +26,6 @@
         .hidden {
             display: none !important;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -47,13 +35,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/Dial.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Dial.html
@@ -26,18 +26,6 @@
         .hidden {
             display: none !important;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -47,13 +35,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/DualAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/DualAction.html
@@ -26,18 +26,6 @@
         .hidden {
             display: none !important;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -47,13 +35,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -32,18 +32,6 @@
             margin-top: 4px;
             line-height: 1.4;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -53,13 +41,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/Momentary.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Momentary.html
@@ -26,18 +26,6 @@
         .hidden {
             display: none !important;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -47,13 +35,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
@@ -32,18 +32,6 @@
             margin-top: 4px;
             line-height: 1.4;
         }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -53,13 +41,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions..."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>

--- a/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
+++ b/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
@@ -23,18 +23,6 @@
         .compact { margin-top: 0; }
         .inline-row { display: flex; align-items: center; gap: 10px; }
         .small-btn { padding: 4px 8px; height: 26px; }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
     </style>
 </head>
 
@@ -44,13 +32,11 @@
     <!-- SEARCH -->
     <div class="sdpi-item">
         <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions."
-                   autocomplete="off">
-        </div>
+        <input type="text"
+               class="sdpi-item-value"
+               id="functionSearch"
+               placeholder="Type to search functions."
+               autocomplete="off">
         <div class="sdpi-item-value"
              id="searchResults"
              style="font-size: 11px; color: #999; margin-top: 4px;"></div>


### PR DESCRIPTION
## Summary
- align property inspector search inputs with the SDPI wrapper markup across Star Citizen action pages
- remove custom search-row styling to rely on the standard SDPI layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568aef83a8832d9e02206ebe04f673)