### PR TITLE
Add target frameworks and runtime identifiers

### DIFF
--- a/InputSimulatorPlus/WindowsInput/WindowsInput.csproj
+++ b/InputSimulatorPlus/WindowsInput/WindowsInput.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>WindowsInput</RootNamespace>
     <AssemblyName>WindowsInput</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworks>net48</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -19,6 +20,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/starcitizen/starcitizen.csproj
+++ b/starcitizen/starcitizen.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>starcitizen</RootNamespace>
     <AssemblyName>com.ltmajor42.starcitizen</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworks>net48</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -30,6 +31,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
## Summary
- declare net48 explicitly via TargetFrameworks in WindowsInput and starcitizen projects
- add win RuntimeIdentifiers entries to align with NuGet requirements

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568e5cec7c832d8706b74350b4481f)