### PR TITLE
Refine property inspector layout

### DIFF
--- a/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionDelay.html
@@ -17,123 +17,133 @@
   <script src="../jquery-3.3.1.min.js"></script>
   <script src="../jquery.highlight-within-textarea.js"></script>
 
-  <style>
-    .note { font-size: 11px; color: #999; line-height: 1.4; }
-    .hidden { display: none; }
-    .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-  </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Search</div>
-    <div class="sdpi-item-value search-row">
-      <input type="text"
-             class="sdpi-item-value"
-             id="functionSearch"
-             placeholder="Type to search functions..."
-             autocomplete="off">
+  <div class="pi-header">
+    <div>
+      <p class="pi-eyebrow">Star Citizen</p>
+      <h1 class="pi-title">Action Delay</h1>
+      <p class="pi-subtitle">Schedule a delayed action with optional visual feedback.</p>
     </div>
-    <div class="sdpi-item-value" id="searchResults"
-         style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+    <div class="pi-badge">Property Inspector</div>
   </div>
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Function</div>
-    <select class="sdpi-item-value select sdProperty"
-            id="function"
-            oninput="setSettings()"
-            onchange="setSettings()">
-      <option value="">Loading Star Citizen functions...</option>
-    </select>
-  </div>
+  <div class="pi-grid">
+    <div class="pi-card">
+      <div class="pi-card-header">
+        <h2 class="pi-card-title">Function & timing</h2>
+        <p class="pi-card-subtitle">Choose the function and tune delay behavior.</p>
+      </div>
+      <div class="pi-card-body">
+        <div class="pi-stack">
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Search</div>
+            <div class="sdpi-item-value search-row">
+              <input type="text"
+                     class="sdpi-item-value"
+                     id="functionSearch"
+                     placeholder="Type to search functions..."
+                     autocomplete="off">
+            </div>
+            <div class="sdpi-item-value pi-helper" id="searchResults"></div>
+          </div>
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Execute after (ms)</div>
-    <input type="number"
-           class="sdpi-item-value sdProperty"
-           id="executionDelayMs"
-           min="100"
-           max="5000"
-           step="10"
-           oninput="setSettings()"
-           onchange="setSettings()">
-  </div>
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Function</div>
+            <select class="sdpi-item-value select sdProperty"
+                    id="function"
+                    oninput="setSettings()"
+                    onchange="setSettings()">
+              <option value="">Loading Star Citizen functions...</option>
+            </select>
+          </div>
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Blink rate (ms)</div>
-    <input type="number"
-           class="sdpi-item-value sdProperty"
-           id="blinkRateMs"
-           min="100"
-           max="1000"
-           step="10"
-           oninput="setSettings()"
-           onchange="setSettings()">
-  </div>
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Execute after (ms)</div>
+            <input type="number"
+                   class="sdpi-item-value sdProperty"
+                   id="executionDelayMs"
+                   min="100"
+                   max="5000"
+                   step="10"
+                   oninput="setSettings()"
+                   onchange="setSettings()">
+          </div>
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Confirm state (ms)</div>
-    <input type="number"
-           class="sdpi-item-value sdProperty"
-           id="confirmationDurationMs"
-           min="100"
-           max="3000"
-           step="10"
-           oninput="setSettings()"
-           onchange="setSettings()">
-  </div>
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Blink rate (ms)</div>
+            <input type="number"
+                   class="sdpi-item-value sdProperty"
+                   id="blinkRateMs"
+                   min="100"
+                   max="1000"
+                   step="10"
+                   oninput="setSettings()"
+                   onchange="setSettings()">
+          </div>
 
-  <div class="sdpi-item">
-    <div class="sdpi-item-label">Tap again to cancel</div>
-    <input type="checkbox"
-           class="sdpi-item-value sdProperty"
-           id="holdToCancel"
-           oninput="setSettings()"
-           onchange="setSettings()">
-  </div>
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Confirm state (ms)</div>
+            <input type="number"
+                   class="sdpi-item-value sdProperty"
+                   id="confirmationDurationMs"
+                   min="100"
+                   max="3000"
+                   step="10"
+                   oninput="setSettings()"
+                   onchange="setSettings()">
+          </div>
 
-  <div class="sdpi-item" id="dvClickSound">
-    <div class="sdpi-item-label">Sound</div>
-    <div class="sdpi-item-group file">
-      <input class="sdpi-item-value sdProperty sdFile"
-             type="file"
-             id="clickSound"
-             accept=".wav"
-             oninput="setSettings(); updateClearSoundVisibility();"
-             onchange="setSettings(); updateClearSoundVisibility();">
-      <label class="sdpi-file-info" id="clickSoundFilename">No file...</label>
-      <label class="sdpi-file-label" for="clickSound">Choose file...</label>
+          <div class="sdpi-item">
+            <div class="sdpi-item-label">Tap again to cancel</div>
+            <input type="checkbox"
+                   class="sdpi-item-value sdProperty"
+                   id="holdToCancel"
+                   oninput="setSettings()"
+                   onchange="setSettings()">
+          </div>
+
+          <div class="sdpi-item no-results hidden" id="noResults">
+            No functions match your search.
+          </div>
+        </div>
+
+        <div class="pi-note-block">
+          Pending blinks by toggling Stream Deck State 0 ↔ State 1. Make sure your State 0 and State 1 images are different.
+        </div>
+      </div>
     </div>
-  </div>
 
-  <div class="sdpi-item hidden" id="dvClearSound">
-    <div class="sdpi-item-label"></div>
-    <button class="sdpi-item-value" onclick="clearClickSound()">Clear sound</button>
-  </div>
+    <div class="pi-card">
+      <div class="pi-card-header">
+        <h2 class="pi-card-title">Feedback</h2>
+        <p class="pi-card-subtitle">Optional click sound when the delayed action fires.</p>
+      </div>
+      <div class="pi-card-body">
+        <div class="pi-stack">
+          <div class="sdpi-item" id="dvClickSound">
+            <div class="sdpi-item-label">Sound</div>
+            <div class="sdpi-item-group file">
+              <input class="sdpi-item-value sdProperty sdFile"
+                     type="file"
+                     id="clickSound"
+                     accept=".wav"
+                     oninput="setSettings(); updateClearSoundVisibility();"
+                     onchange="setSettings(); updateClearSoundVisibility();">
+              <label class="sdpi-file-info" id="clickSoundFilename">No file...</label>
+              <label class="sdpi-file-label" for="clickSound">Choose file...</label>
+            </div>
+          </div>
 
-  <div class="sdpi-item no-results hidden" id="noResults">
-    No functions match your search.
-  </div>
-
-  <div class="sdpi-item">
-    <div class="sdpi-item-label"></div>
-    <div class="sdpi-item-value note">
-      Pending blinks by toggling Stream Deck State 0 ↔ State 1. Make sure your State 0 and State 1 images are different.
+          <div class="sdpi-item hidden" id="dvClearSound">
+            <div class="sdpi-item-label"></div>
+            <button class="sdpi-item-value" onclick="clearClickSound()">Clear sound</button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
+++ b/starcitizen/PropertyInspector/StarCitizen/ActionKey.html
@@ -16,89 +16,92 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Action Key</h1>
+            <p class="pi-subtitle">Assign a single function with optional click feedback.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Function</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="function"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">
-                Loading Star Citizen functions...
-            </option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function picker</h2>
+                <p class="pi-card-subtitle">Search and assign a Star Citizen function.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- CLICK SOUND -->
-    <div class="sdpi-item" id="dvClickSound">
-        <div class="sdpi-item-label">Sound</div>
-        <div class="sdpi-item-group file">
-            <input class="sdpi-item-value sdProperty sdFile"
-                   type="file"
-                   id="clickSound"
-                   accept=".wav"
-                   oninput="setSettings(); updateClearSoundVisibility();"
-                   onchange="setSettings(); updateClearSoundVisibility();">
-            <label class="sdpi-file-info"
-                   id="clickSoundFilename">No file...</label>
-            <label class="sdpi-file-label"
-                   for="clickSound">Choose file...</label>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Function</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="function"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">
+                                Loading Star Citizen functions...
+                            </option>
+                        </select>
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
 
-    <!-- CLEAR SOUND -->
-    <div class="sdpi-item hidden" id="dvClearSound">
-        <div class="sdpi-item-label"></div>
-        <button class="sdpi-item-value" onclick="clearClickSound()">
-            Clear sound
-        </button>
-    </div>
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Feedback</h2>
+                <p class="pi-card-subtitle">Add a confirmation sound for this action.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item" id="dvClickSound">
+                        <div class="sdpi-item-label">Sound</div>
+                        <div class="sdpi-item-group file">
+                            <input class="sdpi-item-value sdProperty sdFile"
+                                   type="file"
+                                   id="clickSound"
+                                   accept=".wav"
+                                   oninput="setSettings(); updateClearSoundVisibility();"
+                                   onchange="setSettings(); updateClearSoundVisibility();">
+                            <label class="sdpi-file-info"
+                                   id="clickSoundFilename">No file...</label>
+                            <label class="sdpi-file-label"
+                                   for="clickSound">Choose file...</label>
+                        </div>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
+                    <div class="sdpi-item hidden" id="dvClearSound">
+                        <div class="sdpi-item-label"></div>
+                        <button class="sdpi-item-value" onclick="clearClickSound()">
+                            Clear sound
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>

--- a/starcitizen/PropertyInspector/StarCitizen/Dial.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Dial.html
@@ -16,112 +16,107 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Dial</h1>
+            <p class="pi-subtitle">Map dial, press, and touch interactions to Star Citizen functions.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION PICKERS -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Dial CW</div>
-        <select class="sdpi-item-value select sdProperty function-select"
-                id="functioncw"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Dial actions</h2>
+                <p class="pi-card-subtitle">Assign functions for every dial gesture.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Dial CCW</div>
-        <select class="sdpi-item-value select sdProperty function-select"
-                id="functionccw"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Dial CW</div>
+                        <select class="sdpi-item-value select sdProperty function-select"
+                                id="functioncw"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Dial Press</div>
-        <select class="sdpi-item-value select sdProperty function-select"
-                id="functionpress"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Dial CCW</div>
+                        <select class="sdpi-item-value select sdProperty function-select"
+                                id="functionccw"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Touch Press</div>
-        <select class="sdpi-item-value select sdProperty function-select"
-                id="functiontouchpress"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Dial Press</div>
+                        <select class="sdpi-item-value select sdProperty function-select"
+                                id="functionpress"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Touch Longpress</div>
-        <select class="sdpi-item-value select sdProperty function-select"
-                id="functiontouchlongpress"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Touch Press</div>
+                        <select class="sdpi-item-value select sdProperty function-select"
+                                id="functiontouchpress"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Touch Delay (ms)</div>
-        <input type="number"
-               class="sdpi-item-value sdProperty"
-               id="delay"
-               min="0"
-               oninput="setSettings()"
-               onchange="setSettings()">
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Touch Longpress</div>
+                        <select class="sdpi-item-value select sdProperty function-select"
+                                id="functiontouchlongpress"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Touch Delay (ms)</div>
+                        <input type="number"
+                               class="sdpi-item-value sdProperty"
+                               id="delay"
+                               min="0"
+                               oninput="setSettings()"
+                               onchange="setSettings()">
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>

--- a/starcitizen/PropertyInspector/StarCitizen/DualAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/DualAction.html
@@ -16,101 +16,101 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Dual Action</h1>
+            <p class="pi-subtitle">Pick separate functions for press and release with optional sound.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- PRESS FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Press action</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="downFunction"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions…</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function pairing</h2>
+                <p class="pi-card-subtitle">Search once and assign actions for press and release.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- RELEASE FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Release action</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="upFunction"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions…</option>
-        </select>
-        <details style="margin-top: 4px; font-size: 11px; color: #999;">
-            <summary>How it works</summary>
-            Press action is held down until you release the key. When released,
-            the press action is released and the optional release action is tapped.
-        </details>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Press action</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="downFunction"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions…</option>
+                        </select>
+                    </div>
 
-    <!-- CLICK SOUND -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Sound</div>
-        <div class="sdpi-item-group file">
-            <input class="sdpi-item-value sdProperty sdFile"
-                   type="file"
-                   id="clickSound"
-                   accept=".wav"
-                   oninput="setSettings(); updateClearSoundVisibility();"
-                   onchange="setSettings(); updateClearSoundVisibility();">
-            <label class="sdpi-file-info" id="clickSoundFilename">No file…</label>
-            <label class="sdpi-file-label" for="clickSound">Choose file…</label>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Release action</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="upFunction"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions…</option>
+                        </select>
+                        <div class="pi-helper">
+                            Press action is held until release. On release the press action stops and the optional release action taps once.
+                        </div>
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
 
-    <!-- CLEAR SOUND BUTTON -->
-    <div class="sdpi-item hidden" id="dvClearSound">
-        <div class="sdpi-item-label"></div>
-        <button class="sdpi-item-value" onclick="clearClickSound()">
-            Clear sound
-        </button>
-    </div>
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Feedback</h2>
+                <p class="pi-card-subtitle">Attach a click sound to the dual action.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Sound</div>
+                        <div class="sdpi-item-group file">
+                            <input class="sdpi-item-value sdProperty sdFile"
+                                   type="file"
+                                   id="clickSound"
+                                   accept=".wav"
+                                   oninput="setSettings(); updateClearSoundVisibility();"
+                                   onchange="setSettings(); updateClearSoundVisibility();">
+                            <label class="sdpi-file-info" id="clickSoundFilename">No file…</label>
+                            <label class="sdpi-file-label" for="clickSound">Choose file…</label>
+                        </div>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
+                    <div class="sdpi-item hidden" id="dvClearSound">
+                        <div class="sdpi-item-label"></div>
+                        <button class="sdpi-item-value" onclick="clearClickSound()">
+                            Clear sound
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -16,89 +16,74 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-        .note {
-            font-size: 11px;
-            color: #999;
-            margin-top: 4px;
-            line-height: 1.4;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Hold Macro</h1>
+            <p class="pi-subtitle">Tap once to press, tap again to release — or hold until you let go.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Function</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="function"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function</h2>
+                <p class="pi-card-subtitle">Search and assign the macro function.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- HOLD UNTIL RELEASE -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Hold Mode</div>
-        <div class="sdpi-item-value">
-            <label for="holdUntilRelease" class="sdpi-item-label" style="width: auto;">
-                <input type="checkbox"
-                       class="sdProperty"
-                       id="holdUntilRelease"
-                       oninput="setSettings(); toggleDuration();"
-                       onchange="setSettings(); toggleDuration();">
-                Hold until release
-            </label>
-        </div>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Function</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="function"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Hold Mode</div>
+                        <div class="sdpi-item-value">
+                            <label for="holdUntilRelease" class="sdpi-item-label" style="width: auto;">
+                                <input type="checkbox"
+                                       class="sdProperty"
+                                       id="holdUntilRelease"
+                                       oninput="setSettings(); toggleDuration();"
+                                       onchange="setSettings(); toggleDuration();">
+                                Hold until release
+                            </label>
+                        </div>
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label"></div>
-        <div class="sdpi-item-value note">
-            Images are managed by Stream Deck (State 0 = idle, State 1 = held). Supports keyboard and mouse tokens.
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+                </div>
+
+                <div class="pi-note-block">
+                    Images are managed by Stream Deck (State 0 = idle, State 1 = held). Supports keyboard and mouse tokens.
+                </div>
+            </div>
         </div>
     </div>
 

--- a/starcitizen/PropertyInspector/StarCitizen/Momentary.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Momentary.html
@@ -16,96 +16,98 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Momentary</h1>
+            <p class="pi-subtitle">Trigger a function once after an optional delay.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Function</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="function"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions…</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function</h2>
+                <p class="pi-card-subtitle">Search, select, and optionally delay execution.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- DELAY -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Delay (ms)</div>
-        <input type="number"
-               class="sdpi-item-value sdProperty"
-               id="delay"
-               min="0"
-               oninput="setSettings()"
-               onchange="setSettings()">
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Function</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="function"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions…</option>
+                        </select>
+                    </div>
 
-    <!-- CLICK SOUND -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Sound</div>
-        <div class="sdpi-item-group file">
-            <input class="sdpi-item-value sdProperty sdFile"
-                   type="file"
-                   id="clickSound"
-                   accept=".wav"
-                   oninput="setSettings(); updateClearSoundVisibility();"
-                   onchange="setSettings(); updateClearSoundVisibility();">
-            <label class="sdpi-file-info" id="clickSoundFilename">No file…</label>
-            <label class="sdpi-file-label" for="clickSound">Choose file…</label>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Delay (ms)</div>
+                        <input type="number"
+                               class="sdpi-item-value sdProperty"
+                               id="delay"
+                               min="0"
+                               oninput="setSettings()"
+                               onchange="setSettings()">
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
 
-    <!-- CLEAR SOUND BUTTON -->
-    <div class="sdpi-item hidden" id="dvClearSound">
-        <div class="sdpi-item-label"></div>
-        <button class="sdpi-item-value" onclick="clearClickSound()">
-            Clear sound
-        </button>
-    </div>
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Feedback</h2>
+                <p class="pi-card-subtitle">Optional click sound after the press.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Sound</div>
+                        <div class="sdpi-item-group file">
+                            <input class="sdpi-item-value sdProperty sdFile"
+                                   type="file"
+                                   id="clickSound"
+                                   accept=".wav"
+                                   oninput="setSettings(); updateClearSoundVisibility();"
+                                   onchange="setSettings(); updateClearSoundVisibility();">
+                            <label class="sdpi-file-info" id="clickSoundFilename">No file…</label>
+                            <label class="sdpi-file-label" for="clickSound">Choose file…</label>
+                        </div>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
+                    <div class="sdpi-item hidden" id="dvClearSound">
+                        <div class="sdpi-item-label"></div>
+                        <button class="sdpi-item-value" onclick="clearClickSound()">
+                            Clear sound
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
 </div>

--- a/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/Repeataction.html
@@ -16,91 +16,74 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results {
-            padding: 10px;
-            color: #999;
-            font-style: italic;
-            text-align: center;
-        }
-        .hidden {
-            display: none !important;
-        }
-        .note {
-            font-size: 11px;
-            color: #999;
-            margin-top: 4px;
-            line-height: 1.4;
-        }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions..."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">Repeat Action</h1>
+            <p class="pi-subtitle">Fire a function continuously while the button is held.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Function</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="function"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions...</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function</h2>
+                <p class="pi-card-subtitle">Search and assign a function to repeat.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions..."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- REPEAT RATE -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Repeat Rate (ms)</div>
-        <input type="number"
-               class="sdpi-item-value sdProperty"
-               id="repeatRate"
-               min="1"
-               oninput="setSettings()"
-               onchange="setSettings()">
-    </div>
-    <div class="sdpi-item">
-        <div class="sdpi-item-label"></div>
-        <div class="sdpi-item-value note">
-            Recommended: 60–80ms (fast), 100ms (default), 120–150ms (precise)
-        </div>
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Function</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="function"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions...</option>
+                        </select>
+                    </div>
 
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
-    </div>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Repeat Rate (ms)</div>
+                        <input type="number"
+                               class="sdpi-item-value sdProperty"
+                               id="repeatRate"
+                               min="1"
+                               oninput="setSettings()"
+                               onchange="setSettings()">
+                    </div>
 
-    <div class="sdpi-item">
-        <div class="sdpi-item-label"></div>
-        <div class="sdpi-item-value note">
-            Images are managed by Stream Deck (State 0 = idle, State 1 = active). Hold to repeat. Release to stop.
+                    <div class="pi-note-block">
+                        Recommended: 60–80ms (fast), 100ms (default), 120–150ms (precise)
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
+
+                    <div class="pi-note-block">
+                        Images are managed by Stream Deck (State 0 = idle, State 1 = active). Hold to repeat. Release to stop.
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
+++ b/starcitizen/PropertyInspector/StarCitizen/StateMemory.html
@@ -16,151 +16,153 @@
     <script src="../jquery-3.3.1.min.js"></script>
     <script src="../jquery.highlight-within-textarea.js"></script>
 
-    <style>
-        .no-results { padding: 10px; color: #999; font-style: italic; text-align: center; }
-        .hidden { display: none !important; }
-        .hint { font-size: 11px; color: #999; line-height: 1.25; margin-top: 4px; }
-        .compact { margin-top: 0; }
-        .inline-row { display: flex; align-items: center; gap: 10px; }
-        .small-btn { padding: 4px 8px; height: 26px; }
-    .search-row {
-        display: flex;
-        gap: 6px;
-        align-items: stretch;
-        min-height: 23px;
-    }
-    .search-row input.sdpi-item-value {
-        flex: 1;
-        height: 100%;
-        min-height: 23px;
-        box-sizing: border-box;
-    }
-    </style>
 </head>
 
-<body>
-<div class="sdpi-wrapper">
+<body class="pi-theme">
+<div class="sdpi-wrapper pi-shell">
 
-    <!-- SEARCH -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Search</div>
-        <div class="sdpi-item-value search-row">
-            <input type="text"
-                   class="sdpi-item-value"
-                   id="functionSearch"
-                   placeholder="Type to search functions."
-                   autocomplete="off">
+    <div class="pi-header">
+        <div>
+            <p class="pi-eyebrow">Star Citizen</p>
+            <h1 class="pi-title">State Memory</h1>
+            <p class="pi-subtitle">Toggle memory while keeping soft sync and audio cues in one place.</p>
         </div>
-        <div class="sdpi-item-value"
-             id="searchResults"
-             style="font-size: 11px; color: #999; margin-top: 4px;"></div>
+        <div class="pi-badge">Property Inspector</div>
     </div>
 
-    <!-- FUNCTION -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Function</div>
-        <select class="sdpi-item-value select sdProperty"
-                id="function"
-                oninput="setSettings()"
-                onchange="setSettings()">
-            <option value="">Loading Star Citizen functions…</option>
-        </select>
-    </div>
+    <div class="pi-grid">
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Function</h2>
+                <p class="pi-card-subtitle">Search and choose the function to pair with memory.</p>
+            </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Search</div>
+                        <div class="sdpi-item-value search-row">
+                            <input type="text"
+                                   class="sdpi-item-value"
+                                   id="functionSearch"
+                                   placeholder="Type to search functions."
+                                   autocomplete="off">
+                        </div>
+                        <div class="sdpi-item-value pi-helper"
+                             id="searchResults"></div>
+                    </div>
 
-    <!-- MEMORY (compact) -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Memory</div>
-        <div class="sdpi-item-value">
-            <div class="inline-row">
-                <input type="checkbox"
-                       class="sdProperty"
-                       id="stateOn"
-                       onchange="setSettings()">
-                <div class="hint compact">
-                    Short press: sends key + flips memory.<br>
-                    Long press: flips memory only (no key sent).
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Function</div>
+                        <select class="sdpi-item-value select sdProperty"
+                                id="function"
+                                oninput="setSettings()"
+                                onchange="setSettings()">
+                            <option value="">Loading Star Citizen functions…</option>
+                        </select>
+                    </div>
+
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Memory</div>
+                        <div class="sdpi-item-value">
+                            <div class="inline-row">
+                                <input type="checkbox"
+                                       class="sdProperty"
+                                       id="stateOn"
+                                       onchange="setSettings()">
+                                <div class="hint compact">
+                                    Short press: sends key + flips memory.<br>
+                                    Long press: flips memory only (no key sent).
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Soft Sync</div>
+                        <input type="checkbox"
+                               class="sdpi-item-value sdProperty"
+                               id="softSyncLongPress"
+                               onchange="setSettings()">
+                    </div>
+
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Long press (ms)</div>
+                        <input type="number"
+                               class="sdpi-item-value sdProperty"
+                               id="longPressMs"
+                               min="0"
+                               oninput="setSettings()"
+                               onchange="setSettings()">
+                    </div>
+
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Keypress delay (ms)</div>
+                        <input type="number"
+                               class="sdpi-item-value sdProperty"
+                               id="keypressDelayMs"
+                               min="0"
+                               oninput="setSettings()"
+                               onchange="setSettings()">
+                    </div>
+
+                    <div class="sdpi-item no-results hidden" id="noResults">
+                        No functions match your search.
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
 
-    <!-- SOFT SYNC -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Soft Sync</div>
-        <input type="checkbox"
-               class="sdpi-item-value sdProperty"
-               id="softSyncLongPress"
-               onchange="setSettings()">
-    </div>
-
-    <!-- LONG PRESS MS -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Long press (ms)</div>
-        <input type="number"
-               class="sdpi-item-value sdProperty"
-               id="longPressMs"
-               min="0"
-               oninput="setSettings()"
-               onchange="setSettings()">
-    </div>
-
-    <!-- KEYPRESS DELAY -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Keypress delay (ms)</div>
-        <input type="number"
-               class="sdpi-item-value sdProperty"
-               id="keypressDelayMs"
-               min="0"
-               oninput="setSettings()"
-               onchange="setSettings()">
-    </div>
-
-    <!-- SOUND: SHORT PRESS -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Sound (short)</div>
-        <div class="sdpi-item-value">
-            <div class="sdpi-item-group file">
-                <input class="sdpi-item-value sdProperty sdFile"
-                       type="file"
-                       id="shortPressSound"
-                       accept=".wav"
-                       oninput="setSettings(); updateClearButtons();"
-                       onchange="setSettings(); updateClearButtons();">
-                <label class="sdpi-file-info" id="shortPressSoundFilename">No file…</label>
-                <label class="sdpi-file-label" for="shortPressSound">Choose file…</label>
+        <div class="pi-card">
+            <div class="pi-card-header">
+                <h2 class="pi-card-title">Feedback</h2>
+                <p class="pi-card-subtitle">Provide separate sounds for short and long presses.</p>
             </div>
-            <button class="sdpi-item-value small-btn hidden"
-                    id="btnClearShort"
-                    onclick="clearSound('shortPressSound')">
-                Clear
-            </button>
-        </div>
-    </div>
+            <div class="pi-card-body">
+                <div class="pi-stack">
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Sound (short)</div>
+                        <div class="sdpi-item-value">
+                            <div class="sdpi-item-group file">
+                                <input class="sdpi-item-value sdProperty sdFile"
+                                       type="file"
+                                       id="shortPressSound"
+                                       accept=".wav"
+                                       oninput="setSettings(); updateClearButtons();"
+                                       onchange="setSettings(); updateClearButtons();">
+                                <label class="sdpi-file-info" id="shortPressSoundFilename">No file…</label>
+                                <label class="sdpi-file-label" for="shortPressSound">Choose file…</label>
+                            </div>
+                            <button class="sdpi-item-value small-btn hidden"
+                                    id="btnClearShort"
+                                    onclick="clearSound('shortPressSound')">
+                                Clear
+                            </button>
+                        </div>
+                    </div>
 
-    <!-- SOUND: LONG PRESS -->
-    <div class="sdpi-item">
-        <div class="sdpi-item-label">Sound (long)</div>
-        <div class="sdpi-item-value">
-            <div class="sdpi-item-group file">
-                <input class="sdpi-item-value sdProperty sdFile"
-                       type="file"
-                       id="longPressSound"
-                       accept=".wav"
-                       oninput="setSettings(); updateClearButtons();"
-                       onchange="setSettings(); updateClearButtons();">
-                <label class="sdpi-file-info" id="longPressSoundFilename">No file…</label>
-                <label class="sdpi-file-label" for="longPressSound">Choose file…</label>
+                    <div class="sdpi-item">
+                        <div class="sdpi-item-label">Sound (long)</div>
+                        <div class="sdpi-item-value">
+                            <div class="sdpi-item-group file">
+                                <input class="sdpi-item-value sdProperty sdFile"
+                                       type="file"
+                                       id="longPressSound"
+                                       accept=".wav"
+                                       oninput="setSettings(); updateClearButtons();"
+                                       onchange="setSettings(); updateClearButtons();">
+                                <label class="sdpi-file-info" id="longPressSoundFilename">No file…</label>
+                                <label class="sdpi-file-label" for="longPressSound">Choose file…</label>
+                            </div>
+                            <button class="sdpi-item-value small-btn hidden"
+                                    id="btnClearLong"
+                                    onclick="clearSound('longPressSound')">
+                                Clear
+                            </button>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <button class="sdpi-item-value small-btn hidden"
-                    id="btnClearLong"
-                    onclick="clearSound('longPressSound')">
-                Clear
-            </button>
         </div>
-    </div>
-
-    <div class="sdpi-item no-results hidden" id="noResults">
-        No functions match your search.
     </div>
 </div>
 

--- a/starcitizen/PropertyInspector/sdpi.css
+++ b/starcitizen/PropertyInspector/sdpi.css
@@ -802,6 +802,184 @@ input[type="radio"]:checked + label span {
 }
 */
 
+/* Shared helpers */
+.hidden {
+  display: none !important;
+}
+
+.no-results {
+  padding: 10px;
+  color: #a9b3c5;
+  font-style: italic;
+  text-align: center;
+}
+
+.search-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+  min-height: 26px;
+}
+
+.search-row input.sdpi-item-value {
+  flex: 1;
+  height: 100%;
+  min-height: 26px;
+  box-sizing: border-box;
+}
+
+.note,
+.hint,
+.pi-helper {
+  font-size: 11px;
+  color: #a9b3c5;
+  line-height: 1.45;
+}
+
+.pi-helper {
+  margin-top: 4px;
+}
+
+.inline-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.compact {
+  margin-top: 0;
+}
+
+.small-btn {
+  padding: 4px 8px;
+  height: 26px;
+}
+
+/* Modernized layout for the property inspector */
+.pi-theme {
+  background: radial-gradient(circle at 22% 20%, #3b4155 0, #2a2f3c 35%, #1d212a 75%);
+  color: #e4e8f3;
+}
+
+.pi-shell {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 12px 14px 18px;
+}
+
+.pi-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, rgba(72, 93, 130, 0.28), rgba(27, 32, 42, 0.85));
+  border: 1px solid #394054;
+  border-radius: 14px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  margin-bottom: 12px;
+}
+
+.pi-title {
+  margin: 0;
+  font-size: 16px;
+  color: #f1f4fb;
+}
+
+.pi-subtitle {
+  margin: 4px 0 0;
+  color: #bcc4d5;
+  font-weight: 400;
+}
+
+.pi-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  color: #93a2c1;
+  margin: 0 0 2px;
+}
+
+.pi-badge {
+  padding: 8px 12px;
+  border: 1px solid #4a5266;
+  border-radius: 999px;
+  background: #252a35;
+  color: #d8deee;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.pi-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pi-card {
+  background: #1f242f;
+  border: 1px solid #2f3544;
+  border-radius: 14px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.32);
+}
+
+.pi-card-header {
+  padding: 12px 16px 0;
+}
+
+.pi-card-title {
+  margin: 2px 0;
+  color: #f3f5fb;
+  font-size: 14px;
+}
+
+.pi-card-subtitle {
+  margin: 4px 0 0;
+  color: #aab2c6;
+  font-weight: 400;
+}
+
+.pi-card-body {
+  padding: 8px 12px 14px;
+}
+
+.pi-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 6px 0 2px;
+}
+
+.pi-stack .sdpi-item {
+  margin-top: 0;
+  padding: 8px 10px;
+  background: #252b37;
+  border: 1px solid #323a4b;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.pi-stack .sdpi-item-label {
+  color: #e5e9f4;
+  font-weight: 600;
+}
+
+.pi-stack .sdpi-item.no-results {
+  justify-content: center;
+  background: #1f2430;
+  border-style: dashed;
+}
+
+.pi-note-block {
+  margin: 4px 0 0;
+  padding: 10px 12px;
+  background: #1c202a;
+  border: 1px solid #32384a;
+  border-radius: 12px;
+  color: #c7cfe0;
+}
+
 input[type="range"] {
   width: var(--sdpi-width);
   height: 30px;
@@ -1355,10 +1533,6 @@ div {
 .noInnerMargins * {
   margin: 0;
   padding: 0;
-}
-
-.hidden {
-  display: none;
 }
 
 .icon-brighter,


### PR DESCRIPTION
## Summary
- add shared helper and theming styles to the property inspector stylesheet for a more polished look
- refresh all Star Citizen inspector pages with the new header, card layout, and updated helper text
- keep existing search, selection, and sound controls while presenting them in a cleaner structure

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695694cb49d4832d86d9ae2e1ef6b2f6)