### PR TITLE
Fix Hold Macro function list loading

### DIFF
--- a/starcitizen/Buttons/HoldMacroAction.cs
+++ b/starcitizen/Buttons/HoldMacroAction.cs
@@ -353,7 +353,9 @@ namespace starcitizen.Buttons
             {
                 var payload = e.ExtractPayload();
 
-                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                var piSignal = payload?["property_inspector"]?.ToString();
+                if (string.Equals(piSignal, "propertyInspectorConnected", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(piSignal, "requestFunctions", StringComparison.OrdinalIgnoreCase))
                 {
                     UpdatePropertyInspector();
                 }

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -181,6 +181,10 @@
     document.addEventListener('websocketCreate', function () {
         const originalOnMessage = websocket.onmessage;
 
+        websocket.addEventListener('open', function () {
+            sendValueToPlugin('requestFunctions', 'property_inspector');
+        });
+
         websocket.onmessage = function (evt) {
             const jsonObj = JSON.parse(evt.data);
 


### PR DESCRIPTION
## Summary
- request the function list from the Hold Macro property inspector as soon as the websocket opens
- handle the new requestFunctions signal in HoldMacroAction so the dropdown repopulates reliably

## Testing
- dotnet build *(fails: dotnet is not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569b6a58f8832db196944b96103949)