### PR TITLE
Fix HoldMacroAction function list population

### DIFF
--- a/starcitizen/Buttons/HoldMacroAction.cs
+++ b/starcitizen/Buttons/HoldMacroAction.cs
@@ -353,7 +353,8 @@ namespace starcitizen.Buttons
             {
                 var payload = e.ExtractPayload();
 
-                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected")
+                if (payload?["property_inspector"]?.ToString() == "propertyInspectorConnected" ||
+                    payload?["requestFunctions"]?.Value<bool>() == true)
                 {
                     UpdatePropertyInspector();
                 }

--- a/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
+++ b/starcitizen/PropertyInspector/StarCitizen/HoldMacroAction.html
@@ -108,6 +108,7 @@
     let allOptions = [];
     let functionsLoaded = false;
     let savedFunctionValue = null;
+    let functionsRequested = false;
 
     /* Preserve selected function if payload arrives before functions list */
     const originalLoadConfiguration = loadConfiguration;
@@ -115,6 +116,11 @@
         if (payload && payload.function !== undefined) {
             savedFunctionValue = payload.function;
         }
+
+        if (payload && payload.functionsLoaded && Array.isArray(payload.functions)) {
+            populateDropdown(payload.functions);
+        }
+
         originalLoadConfiguration(payload);
 
         if (functionsLoaded && savedFunctionValue) {
@@ -122,6 +128,17 @@
             if (sel) sel.value = savedFunctionValue;
         }
     };
+
+    function requestFunctions() {
+        if (functionsLoaded || functionsRequested) {
+            return;
+        }
+
+        if (websocket && websocket.readyState === 1) {
+            functionsRequested = true;
+            sendValueToPlugin(true, 'requestFunctions');
+        }
+    }
 
     function populateDropdown(functions) {
         const select = document.getElementById('function');
@@ -195,6 +212,15 @@
     /* Hook into websocket to receive function list */
     document.addEventListener('websocketCreate', function () {
         const originalOnMessage = websocket.onmessage;
+        const originalOnOpen = websocket.onopen;
+
+        websocket.onopen = function (evt) {
+            if (originalOnOpen) {
+                originalOnOpen.call(this, evt);
+            }
+
+            requestFunctions();
+        };
 
         websocket.onmessage = function (evt) {
             const jsonObj = JSON.parse(evt.data);


### PR DESCRIPTION
## Summary
- Request functions from the property inspector and populate the Hold Macro dropdown when the list arrives.
- Respond to explicit function list requests in the HoldMacroAction plugin so the inspector can refresh reliably.

## Testing
- Not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69569f32e698832da7167c729c69c0b2)